### PR TITLE
Restrict version range of graphql-js peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * ...
 
+### v0.10.0
+* Restrict version range of graphql-js peer dependency to ^0.8.0 || ^0.9.0 [PR #266](https://github.com/apollographql/graphql-tools/pull/266)
+
 ### v0.9.2
 * Update graphql-js dependency to include 0.9.0 [PR #264](https://github.com/apollostack/graphql-tools/pull/264)
 * Fix logErrors option so it logs errors if resolve function returns a promise [PR #262](https://github.com/apollostack/graphql-tools/pull/262)

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "graphql": "^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0"
+    "graphql": "^0.8.0 || ^0.9.0"
   },
   "optionalDependencies": {
     "@types/graphql": "^0.8.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tools",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "A set of useful tools for GraphQL",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
To be merged before the next minor or major version bump so we don't have to worry about supporting features from ancient versions of graphql-js