### PR TITLE
Prevents resolving a property twice in defaultResolverFn

### DIFF
--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -515,7 +515,7 @@ function defaultResolveFn(
   if (typeof source === 'object' || typeof source === 'function') {
     const property = source[fieldName];
     if (typeof property === 'function') {
-      return source[fieldName](args, context);
+      return property(args, context);
     }
     return property;
   }


### PR DESCRIPTION
The property was "resolved" twice.
In case the property is provided by a getter or proxied the two calls are probably less performant then using the already referenced property.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change

Concerning the todos:
Tests: I guess this is covered by the existing tests? If not, the function is private, how would we cope with that?
Do you need a changelog entry for this?