### PR TITLE
Allow Arrays returned by a mock to define the types of their children.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * ...
 
+### v0.10.1
+* Allow setting Union and Interface types for lists [PR #282](https://github.com/apollographql/graphql-tools/pull/282)
+
 ### v0.10.0
 * Restrict version range of graphql-js peer dependency to ^0.8.0 || ^0.9.0 [PR #266](https://github.com/apollographql/graphql-tools/pull/266)
 


### PR DESCRIPTION
Fixes #281 

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
