### PR TITLE
Support schema AST as type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 * Remove dependency on `graphql-subscription` and use an interface for PubSub [PR #295](https://github.com/apollographql/graphql-tools/pull/295)
+* Support schema AST as a type defintion input [PR #300](https://github.com/apollographql/graphql-tools/pull/300)
 
 ### v0.10.1
 * Update dependencies [PR #287](https://github.com/apollographql/graphql-tools/pull/287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### vNEXT
 
 * Remove dependency on `graphql-subscription` and use an interface for PubSub [PR #295](https://github.com/apollographql/graphql-tools/pull/295)
-* Support schema AST as a type defintion input [PR #300](https://github.com/apollographql/graphql-tools/pull/300)
+* Support schema AST as a type definition input [PR #300](https://github.com/apollographql/graphql-tools/pull/300)
 
 ### v0.10.1
 * Update dependencies [PR #287](https://github.com/apollographql/graphql-tools/pull/287)

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -7,6 +7,7 @@ import {
     GraphQLIsTypeOfFn,
     GraphQLTypeResolver,
     GraphQLScalarType,
+    DocumentNode,
 } from 'graphql';
 
 /* TODO: Add documentation */
@@ -23,7 +24,7 @@ export interface IResolverOptions {
     __isTypeOf?: GraphQLIsTypeOfFn<any, any>;
 };
 
-export type ITypedef = (() => ITypedef[]) | string;
+export type ITypedef = (() => ITypedef[]) | string | DocumentNode;
 export type ITypeDefinitions = ITypedef | ITypedef[];
 export type IResolverObject = { [key: string]: GraphQLFieldResolver<any, any> | IResolverOptions };
 export interface IResolvers {

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -6,7 +6,7 @@
 // TODO: we should refactor this file, rename it to makeExecutableSchema, and move
 // a bunch of utility functions into a separate utitlities folder, one file per function.
 
-import { DocumentNode, parse, Kind, DefinitionNode } from 'graphql';
+import { DocumentNode, parse, print, Kind, DefinitionNode } from 'graphql';
 import { uniq } from 'lodash';
 import { buildASTSchema, extendSchema } from 'graphql';
 import {
@@ -117,6 +117,10 @@ function isDocumentNode(typeDefinitions: ITypeDefinitions): typeDefinitions is D
 function concatenateTypeDefs(typeDefinitionsAry: ITypedef[], calledFunctionRefs = [] as any ): string {
   let resolvedTypeDefinitions: string[] = [];
   typeDefinitionsAry.forEach((typeDef: ITypedef) => {
+    if (isDocumentNode(typeDef)) {
+      typeDef = print(typeDef);
+    }
+
     if (typeof typeDef === 'function') {
       if (calledFunctionRefs.indexOf(typeDef) === -1) {
         calledFunctionRefs.push(typeDef);

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -148,8 +148,8 @@ function buildSchemaFromTypeDefinitions(typeDefinitions: ITypeDefinitions): Grap
     astDocument = typeDefinitions;
   } else if (typeof myDefinitions !== 'string') {
     if (!Array.isArray(myDefinitions)) {
-      // TODO improve error message and say what type was actually found
-      throw new SchemaError('`typeDefs` must be a string or array');
+      const type = typeof myDefinitions;
+      throw new SchemaError(`typeDefs must be a string, array or schema AST, got ${type}`);
     }
     myDefinitions = concatenateTypeDefs(myDefinitions);
   }

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -266,16 +266,16 @@ describe('generating schema from shorthand', () => {
   });
 
   it('can generate a schema from a parsed type definition', () => {
-    const typeDefSchemaAry = [parse(`
+    const typeDefSchema = parse(`
       type Query {
         foo: String
       }
       schema {
         query: Query
       }
-    `)];
+    `);
 
-    const jsSchema = makeExecutableSchema({ typeDefs: typeDefSchemaAry, resolvers: {} });
+    const jsSchema = makeExecutableSchema({ typeDefs: typeDefSchema, resolvers: {} });
     expect(jsSchema.getQueryType().name).to.equal('Query');
   });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change

The [webpack loader](https://github.com/apollographql/graphql-tag/blob/master/loader.js) and the [Meteor build plugin](https://github.com/Swydo/meteor-graphql) both return a schema AST when importing a `.graphql` file. It would be great to simply pass this to the `makeExecutableSchema` function without first having to print it.

This PR makes sure that no needless print and parsing is done when an AST is passed. If an Array is passed it will print every AST it finds so that it can be combined with passed schema strings.

See https://github.com/apollographql/graphql-tools/issues/273#issuecomment-289583038

_Example:_
```js
import schema from './data/schema.graphql'; // No need to print with 'graphql/language/printer'
import resolverMap from './data/resolvers';
import { makeExecutableSchema } from 'graphql-tools';

const executableSchema = makeExecutableSchema({
  typeDefs: schema,
  resolvers: resolverMap,
});
```