### PR TITLE
Replace lodash with lodash.uniq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNEXT
+
+* Replace `lodash` with `lodash.uniq` [PR #354](https://github.com/apollographql/graphql-tools/pull/354)
+
 ### v.1.1.0
 * Improve mocking of union and interface types [PR #332](https://github.com/apollographql/graphql-tools/pull/332)
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
     "deprecated-decorator": "^0.1.6",
-    "lodash": "^4.3.0",
+    "lodash.uniq": "^4.5.0",
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/bluebird": "^3.0.32",
     "@types/chai": "3.5.2",
-    "@types/lodash": "^4.14.34",
+    "@types/lodash.uniq": "^4.5.2",
     "@types/mocha": "^2.2.31",
     "@types/node": "^7.0.5",
     "@types/request": "0.0.43",

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -7,7 +7,7 @@
 // a bunch of utility functions into a separate utitlities folder, one file per function.
 
 import { DocumentNode, parse, print, Kind, DefinitionNode } from 'graphql';
-import { uniq } from 'lodash';
+import uniq = require('lodash.uniq');
 import { buildASTSchema, extendSchema } from 'graphql';
 import {
   GraphQLScalarType,


### PR DESCRIPTION
There is no need to use full `lodash` library so it is replaced with `lodash.uniq` as it is the only function used from `lodash`.

Tests are passing, but `tslint` is failing for me (it was failing before the changes too). Since I'm not using ts, I have no idea how to fix this.

```console
// tslint 5.5.0

ERROR: src/mock.ts[145, 29]: Shadowed name: 'mockType'
ERROR: src/schemaGenerator.ts[203, 13]: Shadowed name: 'attachConnectorsToContext'
```

Fixes https://github.com/apollographql/graphql-tools/issues/343
