### PR TITLE
Fixes issue #351

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -278,6 +278,10 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
             return resolvedValue;
         }
 
+        if (resolvedValue instanceof Date && mockedValue instanceof Date) {
+          return (undefined !== resolvedValue) ? resolvedValue : mockedValue;
+        }
+
         if (isObject(mockedValue) && isObject(resolvedValue)) {
           // Object.assign() won't do here, as we need to all properties, including
           // the non-enumerable ones and defined using Object.defineProperty

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -142,7 +142,7 @@ function addMockFunctionsToSchema({ schema, mocks = {}, preserveResolvers = fals
     }
   }
 
-  const mockType = function mockType(type: GraphQLType, typeName?: string, fieldName?: string): GraphQLFieldResolver<any, any> {
+  const mockType = function(type: GraphQLType, typeName?: string, fieldName?: string): GraphQLFieldResolver<any, any> {
     // order of precendence for mocking:
     // 1. if the object passed in already has fieldName, just use that
     // --> if it's a function, that becomes your resolver

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -200,7 +200,7 @@ function forEachField(schema: GraphQLSchema, fn: IFieldIteratorFn): void {
 const attachConnectorsToContext = deprecated<Function>({
     version: '0.7.0',
     url: 'https://github.com/apollostack/graphql-tools/issues/140',
-}, function attachConnectorsToContext(schema: GraphQLSchema, connectors: IConnectors): void {
+}, function(schema: GraphQLSchema, connectors: IConnectors): void {
   if (!schema || !(schema instanceof GraphQLSchema)) {
     throw new Error(
       'schema must be an instance of GraphQLSchema. ' +


### PR DESCRIPTION
A Date was falsely taken to be an object with keys causing issues when
resolvers returned Date instances.