### PR TITLE
Add 'subscribe' property to IResolverOptions

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -20,6 +20,7 @@ export interface IResolverValidationOptions {
 
 export interface IResolverOptions {
     resolve?: GraphQLFieldResolver<any, any>;
+    subscribe?: GraphQLFieldResolver<any, any>;
     __resolveType?: GraphQLTypeResolver<any, any>;
     __isTypeOf?: GraphQLIsTypeOfFn<any, any>;
 }


### PR DESCRIPTION
This fixes issue #372. It seems like the 'subscribe' property was simply missing from the interface definition.

I've tested this by `yarn link`ing the change against another project where I was running into the issue and verified I no longer hit the issue with this diff. 
`npm run test` and `npm run lint` both pass locally.