### PR TITLE
[Do not merge] 2.0 with schema stitching

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 *
 !dist/
 !dist/*
+!dist/stitching/*
 !package.json
 !*.md
 !*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+* Add schema merging utilities [PR #382](https://github.com/apollographql/graphql-tools/pull/382)
+
 ### v1.2.3
 * Update package.json to allow GraphQL.js 0.11 [Issue #394](https://github.com/apollographql/graphql-tools/issues/394) [PR #395](https://github.com/apollographql/graphql-tools/pull/395)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tools",
-  "version": "1.2.3",
+  "version": "2.0.0-alpha.25",
   "description": "A set of useful tools for GraphQL",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tools",
-  "version": "2.0.0-alpha.25",
+  "version": "2.0.0-alpha.26",
   "description": "A set of useful tools for GraphQL",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -81,4 +81,3 @@ export interface IMockServer {
     vars?: { [key: string]: any },
   ) => Promise<ExecutionResult>;
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './schemaGenerator';
 export * from './mock';
+export * from './stitching';

--- a/src/isEmptyObject.ts
+++ b/src/isEmptyObject.ts
@@ -1,0 +1,12 @@
+export default function isEmptyObject(obj: Object): Boolean {
+  if (!obj) {
+    return true;
+  }
+
+  for (const key in obj) {
+    if (Object.hasOwnProperty.call(obj, key)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -112,10 +112,9 @@ function makeExecutableSchema({
   if (typeof resolvers['__schema'] === 'function') {
     // TODO a bit of a hack now, better rewrite generateSchema to attach it there.
     // not doing that now, because I'd have to rewrite a lot of tests.
-    addSchemaLevelResolveFunction(
-      jsSchema,
-      resolvers['__schema'] as GraphQLFieldResolver<any, any>,
-    );
+    addSchemaLevelResolveFunction(jsSchema, resolvers[
+      '__schema'
+    ] as GraphQLFieldResolver<any, any>);
   }
   if (connectors) {
     // connectors are optional, at least for now. That means you can just import them in the resolve
@@ -201,7 +200,7 @@ function buildSchemaFromTypeDefinitions(
   return schema;
 }
 
-function extractExtensionDefinitions(ast: DocumentNode) {
+export function extractExtensionDefinitions(ast: DocumentNode) {
   const extensionDefs = ast.definitions.filter(
     (def: DefinitionNode) => def.kind === Kind.TYPE_EXTENSION_DEFINITION,
   );

--- a/src/stitching/TypeRegistry.ts
+++ b/src/stitching/TypeRegistry.ts
@@ -1,0 +1,123 @@
+import {
+  GraphQLSchema,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLNamedType,
+  GraphQLType,
+  isNamedType,
+  getNamedType,
+  InlineFragmentNode,
+  Kind,
+  parse,
+} from 'graphql';
+
+export default class TypeRegistry {
+  public fragmentReplacements: {
+    [typeName: string]: { [fieldName: string]: InlineFragmentNode };
+  };
+  private types: { [key: string]: GraphQLNamedType };
+  private schemaByField: {
+    query: { [key: string]: GraphQLSchema };
+    mutation: { [key: string]: GraphQLSchema };
+  };
+
+  constructor() {
+    this.types = {};
+    this.schemaByField = {
+      query: {},
+      mutation: {},
+    };
+    this.fragmentReplacements = {};
+  }
+
+  public getSchemaByField(
+    operation: 'query' | 'mutation',
+    fieldName: string,
+  ): GraphQLSchema {
+    return this.schemaByField[operation][fieldName];
+  }
+
+  public getAllTypes(): Array<GraphQLNamedType> {
+    return Object.keys(this.types).map(name => this.types[name]);
+  }
+
+  public getType(name: string): GraphQLNamedType {
+    if (!this.types[name]) {
+      throw new Error(`No such type: ${name}`);
+    }
+    return this.types[name];
+  }
+
+  public resolveType<T extends GraphQLType>(type: T): T {
+    if (type instanceof GraphQLList) {
+      return new GraphQLList(this.resolveType(type.ofType)) as T;
+    } else if (type instanceof GraphQLNonNull) {
+      return new GraphQLNonNull(this.resolveType(type.ofType)) as T;
+    } else if (isNamedType(type)) {
+      return this.getType(getNamedType(type).name) as T;
+    } else {
+      return type;
+    }
+  }
+
+  public addSchema(schema: GraphQLSchema) {
+    const query = schema.getQueryType();
+    if (query) {
+      const fieldNames = Object.keys(query.getFields());
+      fieldNames.forEach(field => {
+        this.schemaByField.query[field] = schema;
+      });
+    }
+
+    const mutation = schema.getMutationType();
+    if (mutation) {
+      const fieldNames = Object.keys(mutation.getFields());
+      fieldNames.forEach(field => {
+        this.schemaByField.mutation[field] = schema;
+      });
+    }
+  }
+
+  public addType(
+    name: string,
+    type: GraphQLNamedType,
+    onTypeConflict?: (
+      leftType: GraphQLNamedType,
+      rightType: GraphQLNamedType,
+    ) => GraphQLNamedType,
+  ): void {
+    if (this.types[name]) {
+      if (onTypeConflict) {
+        type = onTypeConflict(this.types[name], type);
+      } else {
+        throw new Error(`Type name conflict: ${name}`);
+      }
+    }
+    this.types[name] = type;
+  }
+
+  public addFragment(typeName: string, fieldName: string, fragment: string) {
+    if (!this.fragmentReplacements[typeName]) {
+      this.fragmentReplacements[typeName] = {};
+    }
+    this.fragmentReplacements[typeName][
+      fieldName
+    ] = parseFragmentToInlineFragment(fragment);
+  }
+}
+
+function parseFragmentToInlineFragment(
+  definitions: string,
+): InlineFragmentNode {
+  const document = parse(definitions);
+  for (const definition of document.definitions) {
+    if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+      return {
+        kind: Kind.INLINE_FRAGMENT,
+        typeCondition: definition.typeCondition,
+        selectionSet: definition.selectionSet,
+      };
+    }
+  }
+  throw new Error('Could not parse fragment');
+}

--- a/src/stitching/index.ts
+++ b/src/stitching/index.ts
@@ -1,0 +1,5 @@
+import makeRemoteExecutableSchema from './makeRemoteExecutableSchema';
+import introspectSchema from './introspectSchema';
+import mergeSchemas from './mergeSchemas';
+
+export { makeRemoteExecutableSchema, introspectSchema, mergeSchemas };

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -1,0 +1,21 @@
+import { GraphQLSchema } from 'graphql';
+import { introspectionQuery, buildClientSchema } from 'graphql';
+import { Fetcher } from './makeRemoteExecutableSchema';
+
+export default async function introspectSchema(
+  fetcher: Fetcher,
+  context?: { [key: string]: any },
+): Promise<GraphQLSchema> {
+  const introspectionResult = await fetcher({
+    query: introspectionQuery,
+    context,
+  });
+  if (introspectionResult.errors || !introspectionResult.data.__schema) {
+    throw introspectionResult.errors;
+  } else {
+    const schema = buildClientSchema(introspectionResult.data as {
+      __schema: any;
+    });
+    return schema;
+  }
+}

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -1,0 +1,161 @@
+import { printSchema, print, ExecutionResult, Kind, ValueNode } from 'graphql';
+import {
+  GraphQLFieldResolver,
+  GraphQLSchema,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLID,
+  GraphQLString,
+  GraphQLFloat,
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLScalarType,
+} from 'graphql';
+import isEmptyObject from '../isEmptyObject';
+import { IResolvers, IResolverObject } from '../Interfaces';
+import { makeExecutableSchema } from '../schemaGenerator';
+import resolveParentFromTypename from './resolveFromParentTypename';
+
+export type Fetcher = (
+  operation: {
+    query: string;
+    operationName?: string;
+    variables?: { [key: string]: any };
+    context?: { [key: string]: any };
+  },
+) => Promise<ExecutionResult>;
+
+export default function makeRemoteExecutableSchema({
+  schema,
+  fetcher,
+}: {
+  schema: GraphQLSchema;
+  fetcher: Fetcher;
+}): GraphQLSchema {
+  const queryType = schema.getQueryType();
+  const queries = queryType.getFields();
+  const queryResolvers: IResolverObject = {};
+  Object.keys(queries).forEach(key => {
+    queryResolvers[key] = createResolver(fetcher);
+  });
+  let mutationResolvers: IResolverObject = {};
+  const mutationType = schema.getMutationType();
+  if (mutationType) {
+    const mutations = mutationType.getFields();
+    Object.keys(mutations).forEach(key => {
+      mutationResolvers[key] = createResolver(fetcher);
+    });
+  }
+
+  const resolvers: IResolvers = { [queryType.name]: queryResolvers };
+
+  if (!isEmptyObject(mutationResolvers)) {
+    resolvers[mutationType.name] = mutationResolvers;
+  }
+
+  const typeMap = schema.getTypeMap();
+  const types = Object.keys(typeMap).map(name => typeMap[name]);
+  for (const type of types) {
+    if (
+      type instanceof GraphQLInterfaceType ||
+      type instanceof GraphQLUnionType
+    ) {
+      resolvers[type.name] = {
+        __resolveType(parent, context, info) {
+          return resolveParentFromTypename(parent, info.schema);
+        },
+      };
+    } else if (type instanceof GraphQLScalarType) {
+      if (
+        !(
+          type === GraphQLID ||
+          type === GraphQLString ||
+          type === GraphQLFloat ||
+          type === GraphQLBoolean ||
+          type === GraphQLInt
+        )
+      ) {
+        resolvers[type.name] = createPassThroughScalar(type);
+      }
+    }
+  }
+
+  const typeDefs = printSchema(schema);
+
+  return makeExecutableSchema({
+    typeDefs,
+    resolvers,
+  });
+}
+
+function createResolver(fetcher: Fetcher): GraphQLFieldResolver<any, any> {
+  return async (root, args, context, info) => {
+    const operation = print(info.operation);
+    const fragments = Object.keys(info.fragments)
+      .map(fragment => print(info.fragments[fragment]))
+      .join('\n');
+    const query = `${operation}\n${fragments}`;
+    const result = await fetcher({
+      query,
+      variables: info.variableValues,
+      context,
+    });
+    const fieldName = info.fieldNodes[0].alias
+      ? info.fieldNodes[0].alias.value
+      : info.fieldName;
+    if (result.errors) {
+      const errorMessage = result.errors.map(error => error.message).join('\n');
+      throw new Error(errorMessage);
+    } else {
+      return result.data[fieldName];
+    }
+  };
+}
+
+function createPassThroughScalar({
+  name,
+  description,
+}: {
+  name: string;
+  description: string;
+}): GraphQLScalarType {
+  return new GraphQLScalarType({
+    name: name,
+    description: description,
+    serialize(value) {
+      return value;
+    },
+    parseValue(value) {
+      return value;
+    },
+    parseLiteral(ast) {
+      return parseLiteral(ast);
+    },
+  });
+}
+
+function parseLiteral(ast: ValueNode): any {
+  switch (ast.kind) {
+    case Kind.STRING:
+    case Kind.BOOLEAN: {
+      return ast.value;
+    }
+    case Kind.INT:
+    case Kind.FLOAT: {
+      return parseFloat(ast.value);
+    }
+    case Kind.OBJECT: {
+      const value = Object.create(null);
+      ast.fields.forEach(field => {
+        value[field.name.value] = parseLiteral(field.value);
+      });
+
+      return value;
+    }
+    case Kind.LIST: {
+      return ast.values.map(parseLiteral);
+    }
+    default:
+      return null;
+  }
+}

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -560,9 +560,14 @@ function processRootField(
 } {
   const existingArguments = selection.arguments || [];
   const existingArgumentNames = existingArguments.map(arg => arg.name.value);
+  const allowedArguments = rootField.args.map(arg => arg.name);
   const missingArgumentNames = difference(
-    rootField.args.map(arg => arg.name),
+    allowedArguments,
     existingArgumentNames,
+  );
+  const extraArguments = difference(existingArgumentNames, allowedArguments);
+  const filteredExistingArguments = existingArguments.filter(
+    arg => extraArguments.indexOf(arg.name.value) === -1,
   );
   const variables: Array<{ arg: string; variable: string }> = [];
   const missingArguments = missingArgumentNames.map(name => {
@@ -592,7 +597,7 @@ function processRootField(
     selection: {
       kind: Kind.FIELD,
       alias: null,
-      arguments: [...existingArguments, ...missingArguments],
+      arguments: [...filteredExistingArguments, ...missingArguments],
       selectionSet: selection.selectionSet,
       name: {
         kind: Kind.NAME,

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -1,0 +1,907 @@
+import {
+  DocumentNode,
+  FieldNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  GraphQLArgument,
+  GraphQLArgumentConfig,
+  GraphQLCompositeType,
+  GraphQLField,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLFieldMap,
+  GraphQLFieldResolver,
+  GraphQLInputField,
+  GraphQLInputFieldConfig,
+  GraphQLInputFieldConfigMap,
+  GraphQLInputFieldMap,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLResolveInfo,
+  GraphQLScalarType,
+  GraphQLSchema,
+  GraphQLType,
+  GraphQLNamedType,
+  GraphQLUnionType,
+  InlineFragmentNode,
+  Kind,
+  OperationDefinitionNode,
+  SelectionSetNode,
+  TypeNode,
+  TypeNameMetaFieldDef,
+  VariableDefinitionNode,
+  VariableNode,
+  buildASTSchema,
+  execute,
+  getNamedType,
+  isCompositeType,
+  isNamedType,
+  parse,
+  visit,
+  extendSchema,
+} from 'graphql';
+import TypeRegistry from './TypeRegistry';
+import { IResolvers } from '../Interfaces';
+import isEmptyObject from '../isEmptyObject';
+import {
+  extractExtensionDefinitions,
+  addResolveFunctionsToSchema,
+} from '../schemaGenerator';
+import resolveFromParentTypename from './resolveFromParentTypename';
+
+export type MergeInfo = {
+  delegate: (
+    type: 'query' | 'mutation',
+    fieldName: string,
+    args: { [key: string]: any },
+    context: { [key: string]: any },
+    info: GraphQLResolveInfo,
+  ) => any;
+};
+
+function defaultOnTypeConflict(
+  left: GraphQLNamedType,
+  right: GraphQLNamedType,
+): GraphQLNamedType {
+  return left;
+}
+
+export default function mergeSchemas({
+  schemas,
+  onTypeConflict,
+  resolvers,
+}: {
+  schemas: Array<GraphQLSchema | string>;
+  onTypeConflict?: (
+    leftType: GraphQLNamedType,
+    rightType: GraphQLNamedType,
+  ) => GraphQLNamedType;
+  resolvers: (mergeInfo: MergeInfo) => IResolvers;
+}): GraphQLSchema {
+  if (!onTypeConflict) {
+    onTypeConflict = defaultOnTypeConflict;
+  }
+  let queryFields: GraphQLFieldConfigMap<any, any> = {};
+  let mutationFields: GraphQLFieldConfigMap<any, any> = {};
+
+  const typeRegistry = new TypeRegistry();
+
+  const mergeInfo: MergeInfo = createMergeInfo(typeRegistry);
+
+  const actualSchemas: Array<GraphQLSchema> = [];
+  const extensions: Array<DocumentNode> = [];
+  let fullResolvers: IResolvers = {};
+
+  schemas.forEach(schema => {
+    if (schema instanceof GraphQLSchema) {
+      actualSchemas.push(schema);
+    } else if (typeof schema === 'string') {
+      let parsedSchemaDocument = parse(schema);
+      try {
+        const actualSchema = buildASTSchema(parsedSchemaDocument);
+        actualSchemas.push(actualSchema);
+      } catch (e) {
+        // Could not create a schema from parsed string, will use extensions
+      }
+      parsedSchemaDocument = extractExtensionDefinitions(parsedSchemaDocument);
+      if (parsedSchemaDocument.definitions.length > 0) {
+        extensions.push(parsedSchemaDocument);
+      }
+    }
+  });
+
+  actualSchemas.forEach(schema => {
+    typeRegistry.addSchema(schema);
+    const queryType = schema.getQueryType();
+    const mutationType = schema.getMutationType();
+
+    const typeMap = schema.getTypeMap();
+    Object.keys(typeMap).forEach(typeName => {
+      const type: GraphQLType = typeMap[typeName];
+      if (
+        isNamedType(type) &&
+        getNamedType(type).name.slice(0, 2) !== '__' &&
+        type !== queryType &&
+        type !== mutationType
+      ) {
+        let newType;
+        if (isCompositeType(type) || type instanceof GraphQLInputObjectType) {
+          newType = recreateCompositeType(schema, type, typeRegistry);
+        } else {
+          newType = getNamedType(type);
+        }
+        typeRegistry.addType(newType.name, newType, onTypeConflict);
+      }
+    });
+  });
+
+  // This is not a bug/oversight, we iterate twice cause we want to first
+  // resolve all types and then force the type thunks
+  actualSchemas.forEach(schema => {
+    const queryType = schema.getQueryType();
+    const mutationType = schema.getMutationType();
+    Object.keys(queryType.getFields()).forEach(name => {
+      if (!fullResolvers.Query) {
+        fullResolvers.Query = {};
+      }
+      fullResolvers.Query[name] = createDelegatingResolver(
+        mergeInfo,
+        'query',
+        name,
+      );
+    });
+
+    queryFields = {
+      ...queryFields,
+      ...fieldMapToFieldConfigMap(queryType.getFields(), typeRegistry),
+    };
+
+    if (mutationType) {
+      if (!fullResolvers.Mutation) {
+        fullResolvers.Mutation = {};
+      }
+      Object.keys(mutationType.getFields()).forEach(name => {
+        fullResolvers.Mutation[name] = createDelegatingResolver(
+          mergeInfo,
+          'mutation',
+          name,
+        );
+      });
+
+      mutationFields = {
+        ...mutationFields,
+        ...fieldMapToFieldConfigMap(mutationType.getFields(), typeRegistry),
+      };
+    }
+  });
+
+  let passedResolvers = {};
+  if (resolvers) {
+    passedResolvers = resolvers(mergeInfo);
+  }
+
+  Object.keys(passedResolvers).forEach(typeName => {
+    const type = passedResolvers[typeName];
+    if (type instanceof GraphQLScalarType) {
+      return;
+    }
+    Object.keys(type).forEach(fieldName => {
+      const field = type[fieldName];
+      if (field.fragment) {
+        typeRegistry.addFragment(typeName, fieldName, field.fragment);
+      }
+    });
+  });
+
+  fullResolvers = mergeDeep(fullResolvers, passedResolvers);
+
+  const query = new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      ...queryFields,
+    },
+  });
+
+  let mutation;
+  if (!isEmptyObject(mutationFields)) {
+    mutation = new GraphQLObjectType({
+      name: 'Mutation',
+      fields: {
+        ...mutationFields,
+      },
+    });
+  }
+
+  let mergedSchema = new GraphQLSchema({
+    query,
+    mutation,
+    types: typeRegistry.getAllTypes(),
+  });
+
+  extensions.forEach(extension => {
+    mergedSchema = extendSchema(mergedSchema, extension);
+  });
+
+  addResolveFunctionsToSchema(mergedSchema, fullResolvers);
+
+  return mergedSchema;
+}
+
+function recreateCompositeType(
+  schema: GraphQLSchema,
+  type: GraphQLCompositeType | GraphQLInputObjectType,
+  registry: TypeRegistry,
+): GraphQLCompositeType | GraphQLInputObjectType {
+  if (type instanceof GraphQLObjectType) {
+    const fields = type.getFields();
+    const interfaces = type.getInterfaces();
+
+    return new GraphQLObjectType({
+      name: type.name,
+      description: type.description,
+      isTypeOf: type.isTypeOf,
+      fields: () => fieldMapToFieldConfigMap(fields, registry),
+      interfaces: () => interfaces.map(iface => registry.resolveType(iface)),
+    });
+  } else if (type instanceof GraphQLInterfaceType) {
+    const fields = type.getFields();
+
+    return new GraphQLInterfaceType({
+      name: type.name,
+      description: type.description,
+      fields: () => fieldMapToFieldConfigMap(fields, registry),
+      resolveType: (parent, context, info) =>
+        resolveFromParentTypename(parent, info.schema),
+    });
+  } else if (type instanceof GraphQLUnionType) {
+    return new GraphQLUnionType({
+      name: type.name,
+      description: type.description,
+      types: () =>
+        type.getTypes().map(unionMember => registry.resolveType(unionMember)),
+      resolveType: (parent, context, info) =>
+        resolveFromParentTypename(parent, info.schema),
+    });
+  } else if (type instanceof GraphQLInputObjectType) {
+    return new GraphQLInputObjectType({
+      name: type.name,
+      description: type.description,
+      fields: () => inputFieldMapToFieldConfigMap(type.getFields(), registry),
+    });
+  } else {
+    throw new Error(`Invalid type ${type}`);
+  }
+}
+
+function fieldMapToFieldConfigMap(
+  fields: GraphQLFieldMap<any, any>,
+  registry: TypeRegistry,
+): GraphQLFieldConfigMap<any, any> {
+  const result: GraphQLFieldConfigMap<any, any> = {};
+  Object.keys(fields).forEach(name => {
+    result[name] = fieldToFieldConfig(fields[name], registry);
+  });
+  return result;
+}
+
+function fieldToFieldConfig(
+  field: GraphQLField<any, any>,
+  registry: TypeRegistry,
+): GraphQLFieldConfig<any, any> {
+  return {
+    type: registry.resolveType(field.type),
+    args: argsToFieldConfigArgumentMap(field.args, registry),
+    description: field.description,
+    deprecationReason: field.deprecationReason,
+  };
+}
+
+function argsToFieldConfigArgumentMap(
+  args: Array<GraphQLArgument>,
+  registry: TypeRegistry,
+): GraphQLFieldConfigArgumentMap {
+  const result: GraphQLFieldConfigArgumentMap = {};
+  args.forEach(arg => {
+    const [name, def] = argumentToArgumentConfig(arg, registry);
+    result[name] = def;
+  });
+  return result;
+}
+
+function argumentToArgumentConfig(
+  argument: GraphQLArgument,
+  registry: TypeRegistry,
+): [string, GraphQLArgumentConfig] {
+  return [
+    argument.name,
+    {
+      type: registry.resolveType(argument.type),
+      defaultValue: argument.defaultValue,
+      description: argument.description,
+    },
+  ];
+}
+
+function inputFieldMapToFieldConfigMap(
+  fields: GraphQLInputFieldMap,
+  registry: TypeRegistry,
+): GraphQLInputFieldConfigMap {
+  const result: GraphQLInputFieldConfigMap = {};
+  Object.keys(fields).forEach(name => {
+    result[name] = inputFieldToFieldConfig(fields[name], registry);
+  });
+  return result;
+}
+
+function inputFieldToFieldConfig(
+  field: GraphQLInputField,
+  registry: TypeRegistry,
+): GraphQLInputFieldConfig {
+  return {
+    type: registry.resolveType(field.type),
+    description: field.description,
+  };
+}
+
+function createMergeInfo(typeRegistry: TypeRegistry): MergeInfo {
+  return {
+    delegate(
+      operation: 'query' | 'mutation',
+      fieldName: string,
+      args: { [key: string]: any },
+      context: { [key: string]: any },
+      info: GraphQLResolveInfo,
+    ): any {
+      const schema = typeRegistry.getSchemaByField(operation, fieldName);
+      if (!schema) {
+        throw new Error(
+          `Cannot find subschema for root field ${operation}.${fieldName}`,
+        );
+      }
+      const fragmentReplacements = typeRegistry.fragmentReplacements;
+      return delegateToSchema(
+        schema,
+        fragmentReplacements,
+        operation,
+        fieldName,
+        args,
+        context,
+        info,
+      );
+    },
+  };
+}
+
+function createDelegatingResolver(
+  mergeInfo: MergeInfo,
+  operation: 'query' | 'mutation',
+  fieldName: string,
+): GraphQLFieldResolver<any, any> {
+  return (root, args, context, info) => {
+    return mergeInfo.delegate(operation, fieldName, args, context, info);
+  };
+}
+
+async function delegateToSchema(
+  schema: GraphQLSchema,
+  fragmentReplacements: {
+    [typeName: string]: { [fieldName: string]: InlineFragmentNode };
+  },
+  operation: 'query' | 'mutation',
+  fieldName: string,
+  args: { [key: string]: any },
+  context: { [key: string]: any },
+  info: GraphQLResolveInfo,
+): Promise<any> {
+  let type;
+  if (operation === 'mutation') {
+    type = schema.getMutationType();
+  } else {
+    type = schema.getQueryType();
+  }
+  if (type) {
+    const graphqlDoc: DocumentNode = createDocument(
+      schema,
+      fragmentReplacements,
+      type,
+      fieldName,
+      operation,
+      info.fieldNodes,
+      info.fragments,
+      info.operation.variableDefinitions,
+    );
+
+    const operationDefinition = graphqlDoc.definitions.find(
+      ({ kind }) => kind === Kind.OPERATION_DEFINITION,
+    );
+    let variableValues = {};
+    if (
+      operationDefinition &&
+      operationDefinition.kind === Kind.OPERATION_DEFINITION &&
+      operationDefinition.variableDefinitions
+    ) {
+      operationDefinition.variableDefinitions.forEach(definition => {
+        const key = definition.variable.name.value;
+        // (XXX) This is kinda hacky
+        let actualKey = key;
+        if (actualKey.startsWith('_')) {
+          actualKey = actualKey.slice(1);
+        }
+        const value = args[actualKey] || args[key] || info.variableValues[key];
+        variableValues[key] = value;
+      });
+    }
+
+    const result = await execute(
+      schema,
+      graphqlDoc,
+      info.rootValue,
+      context,
+      variableValues,
+    );
+
+    // const print = require('graphql').print;
+    // console.log(
+    //   'RESULT FROM FORWARDING\n',
+    //   print(graphqlDoc),
+    //   '\n',
+    //   JSON.stringify(variableValues, null, 2),
+    //   '\n',
+    //   JSON.stringify(result, null, 2),
+    // );
+
+    if (result.errors) {
+      const errorMessage = result.errors.map(error => error.message).join('\n');
+      throw new Error(errorMessage);
+    } else {
+      return result.data[fieldName];
+    }
+  }
+
+  throw new Error('Could not forward to merged schema');
+}
+
+function createDocument(
+  schema: GraphQLSchema,
+  fragmentReplacements: {
+    [typeName: string]: { [fieldName: string]: InlineFragmentNode };
+  },
+  type: GraphQLObjectType,
+  rootFieldName: string,
+  operation: 'query' | 'mutation',
+  selections: Array<FieldNode>,
+  fragments: { [fragmentName: string]: FragmentDefinitionNode },
+  variableDefinitions?: Array<VariableDefinitionNode>,
+): DocumentNode {
+  const rootField = type.getFields()[rootFieldName];
+  const newVariables: Array<{ arg: string; variable: string }> = [];
+  const rootSelectionSet = {
+    kind: Kind.SELECTION_SET,
+    // (XXX) This (wrongly) assumes only having one fieldNode
+    selections: selections.map(selection => {
+      if (selection.kind === Kind.FIELD) {
+        const { selection: newSelection, variables } = processRootField(
+          selection,
+          rootFieldName,
+          rootField,
+        );
+        newVariables.push(...variables);
+        return newSelection;
+      } else {
+        return selection;
+      }
+    }),
+  };
+
+  const newVariableDefinitions = newVariables.map(({ arg, variable }) => {
+    const argDef = rootField.args.find(rootArg => rootArg.name === arg);
+    if (!argDef) {
+      throw new Error('Unexpected missing arg');
+    }
+    const typeName = typeToAst(argDef.type);
+    return {
+      kind: Kind.VARIABLE_DEFINITION,
+      variable: {
+        kind: Kind.VARIABLE,
+        name: {
+          kind: Kind.NAME,
+          value: variable,
+        },
+      },
+      type: typeName,
+    };
+  });
+
+  const {
+    selectionSet,
+    fragments: processedFragments,
+    usedVariables,
+  } = filterSelectionSetDeep(
+    schema,
+    fragmentReplacements,
+    type,
+    rootSelectionSet,
+    fragments,
+  );
+
+  const operationDefinition: OperationDefinitionNode = {
+    kind: Kind.OPERATION_DEFINITION,
+    operation,
+    variableDefinitions: [
+      ...(variableDefinitions || []).filter(
+        variableDefinition =>
+          usedVariables.indexOf(variableDefinition.variable.name.value) !== -1,
+      ),
+      ...newVariableDefinitions,
+    ],
+    selectionSet,
+  };
+
+  const newDoc: DocumentNode = {
+    kind: Kind.DOCUMENT,
+    definitions: [operationDefinition, ...processedFragments],
+  };
+
+  return newDoc;
+}
+
+function processRootField(
+  selection: FieldNode,
+  rootFieldName: string,
+  rootField: GraphQLField<any, any>,
+): {
+  selection: FieldNode;
+  variables: Array<{ arg: string; variable: string }>;
+} {
+  const existingArguments = selection.arguments || [];
+  const existingArgumentNames = existingArguments.map(arg => arg.name.value);
+  const missingArgumentNames = difference(
+    rootField.args.map(arg => arg.name),
+    existingArgumentNames,
+  );
+  const variables: Array<{ arg: string; variable: string }> = [];
+  const missingArguments = missingArgumentNames.map(name => {
+    // (XXX): really needs better var generation
+    const variableName = `_${name}`;
+    variables.push({
+      arg: name,
+      variable: variableName,
+    });
+    return {
+      kind: Kind.ARGUMENT,
+      name: {
+        kind: Kind.NAME,
+        value: name,
+      },
+      value: {
+        kind: Kind.VARIABLE,
+        name: {
+          kind: Kind.NAME,
+          value: variableName,
+        },
+      },
+    };
+  });
+
+  return {
+    selection: {
+      kind: Kind.FIELD,
+      alias: null,
+      arguments: [...existingArguments, ...missingArguments],
+      selectionSet: selection.selectionSet,
+      name: {
+        kind: Kind.NAME,
+        value: rootFieldName,
+      },
+    },
+    variables,
+  };
+}
+
+function filterSelectionSetDeep(
+  schema: GraphQLSchema,
+  fragmentReplacements: {
+    [typeName: string]: { [fieldName: string]: InlineFragmentNode };
+  },
+  type: GraphQLType,
+  selectionSet: SelectionSetNode,
+  fragments: { [fragmentName: string]: FragmentDefinitionNode },
+): {
+  selectionSet: SelectionSetNode;
+  fragments: Array<FragmentDefinitionNode>;
+  usedVariables: Array<string>;
+} {
+  const validFragments: Array<string> = [];
+  Object.keys(fragments).forEach(fragmentName => {
+    const fragment = fragments[fragmentName];
+    const typeName = fragment.typeCondition.name.value;
+    const innerType = schema.getType(typeName);
+    if (innerType) {
+      validFragments.push(fragment.name.value);
+    }
+  });
+  let {
+    selectionSet: newSelectionSet,
+    usedFragments: remainingFragments,
+    usedVariables,
+  } = filterSelectionSet(
+    schema,
+    fragmentReplacements,
+    type,
+    selectionSet,
+    validFragments,
+  );
+
+  const newFragments = {};
+  // (XXX): So this will break if we have a fragment that only has link fields
+  while (remainingFragments.length > 0) {
+    const name = remainingFragments.pop();
+    if (newFragments[name]) {
+      continue;
+    } else {
+      const nextFragment = fragments[name];
+      if (!name) {
+        throw new Error(`Could not find fragment ${name}`);
+      }
+      const typeName = nextFragment.typeCondition.name.value;
+      const innerType = schema.getType(typeName);
+      if (!innerType) {
+        continue;
+      }
+      const {
+        selectionSet: fragmentSelectionSet,
+        usedFragments: fragmentUsedFragments,
+        usedVariables: fragmentUsedVariables,
+      } = filterSelectionSet(
+        schema,
+        fragmentReplacements,
+        innerType,
+        nextFragment.selectionSet,
+        validFragments,
+      );
+      remainingFragments = union(remainingFragments, fragmentUsedFragments);
+      usedVariables = union(usedVariables, fragmentUsedVariables);
+      newFragments[name] = {
+        kind: Kind.FRAGMENT_DEFINITION,
+        name: {
+          kind: Kind.NAME,
+          value: name,
+        },
+        typeCondition: nextFragment.typeCondition,
+        selectionSet: fragmentSelectionSet,
+      };
+    }
+  }
+  const newFragmentValues: Array<FragmentDefinitionNode> = Object.keys(
+    newFragments,
+  ).map(name => newFragments[name]);
+  return {
+    selectionSet: newSelectionSet,
+    fragments: newFragmentValues,
+    usedVariables,
+  };
+}
+
+function filterSelectionSet(
+  schema: GraphQLSchema,
+  fragmentReplacements: {
+    [typeName: string]: { [fieldName: string]: InlineFragmentNode };
+  },
+  type: GraphQLType,
+  selectionSet: SelectionSetNode,
+  validFragments: Array<string>,
+): {
+  selectionSet: SelectionSetNode;
+  usedFragments: Array<string>;
+  usedVariables: Array<string>;
+} {
+  const usedFragments: Array<string> = [];
+  const usedVariables: Array<string> = [];
+  const typeStack: Array<GraphQLType> = [type];
+  const filteredSelectionSet = visit(selectionSet, {
+    [Kind.FIELD]: {
+      enter(node: FieldNode): null | undefined {
+        let parentType: GraphQLType = resolveType(
+          typeStack[typeStack.length - 1],
+        );
+        if (
+          parentType instanceof GraphQLNonNull ||
+          parentType instanceof GraphQLList
+        ) {
+          parentType = parentType.ofType;
+        }
+        if (
+          parentType instanceof GraphQLObjectType ||
+          parentType instanceof GraphQLInterfaceType
+        ) {
+          const fields = parentType.getFields();
+          const field =
+            node.name.value === '__typename'
+              ? TypeNameMetaFieldDef
+              : fields[node.name.value];
+          if (!field) {
+            return null;
+          } else {
+            typeStack.push(field.type);
+          }
+        }
+      },
+      leave() {
+        typeStack.pop();
+      },
+    },
+    [Kind.SELECTION_SET](
+      node: SelectionSetNode,
+    ): SelectionSetNode | null | undefined {
+      const parentType: GraphQLType = resolveType(
+        typeStack[typeStack.length - 1],
+      );
+      const parentTypeName = parentType.name;
+      let selections = node.selections;
+      if (
+        parentType instanceof GraphQLInterfaceType ||
+        parentType instanceof GraphQLUnionType
+      ) {
+        selections = selections.concat({
+          kind: Kind.FIELD,
+          name: {
+            kind: Kind.NAME,
+            value: '__typename',
+          },
+        });
+      }
+
+      if (fragmentReplacements[parentTypeName]) {
+        selections.forEach(selection => {
+          if (selection.kind === Kind.FIELD) {
+            const name = selection.name.value;
+            const fragment = fragmentReplacements[parentTypeName][name];
+            if (fragment) {
+              selections = selections.concat(fragment);
+            }
+          }
+        });
+      }
+
+      if (selections !== node.selections) {
+        return {
+          ...node,
+          selections,
+        };
+      }
+    },
+    [Kind.FRAGMENT_SPREAD](node: FragmentSpreadNode): null | undefined {
+      if (validFragments.indexOf(node.name.value) !== -1) {
+        usedFragments.push(node.name.value);
+      } else {
+        return null;
+      }
+    },
+    [Kind.INLINE_FRAGMENT]: {
+      enter(node: InlineFragmentNode): null | undefined {
+        if (node.typeCondition) {
+          const innerType = schema.getType(node.typeCondition.name.value);
+          if (innerType) {
+            typeStack.push(innerType);
+          } else {
+            return null;
+          }
+        }
+      },
+      leave(node: InlineFragmentNode): null | undefined {
+        if (node.typeCondition) {
+          const innerType = schema.getType(node.typeCondition.name.value);
+          if (innerType) {
+            typeStack.pop();
+          } else {
+            return null;
+          }
+        }
+      },
+    },
+    [Kind.VARIABLE](node: VariableNode) {
+      usedVariables.push(node.name.value);
+    },
+  });
+
+  return {
+    selectionSet: filteredSelectionSet,
+    usedFragments,
+    usedVariables,
+  };
+}
+
+function resolveType(type: GraphQLType): GraphQLNamedType {
+  let lastType = type;
+  while (
+    lastType instanceof GraphQLNonNull ||
+    lastType instanceof GraphQLList
+  ) {
+    lastType = lastType.ofType;
+  }
+  return lastType;
+}
+
+function typeToAst(type: GraphQLInputType): TypeNode {
+  if (type instanceof GraphQLNonNull) {
+    const innerType = typeToAst(type.ofType);
+    if (
+      innerType.kind === Kind.LIST_TYPE ||
+      innerType.kind === Kind.NAMED_TYPE
+    ) {
+      return {
+        kind: Kind.NON_NULL_TYPE,
+        type: innerType,
+      };
+    } else {
+      throw new Error('Incorrent inner non-null type');
+    }
+  } else if (type instanceof GraphQLList) {
+    return {
+      kind: Kind.LIST_TYPE,
+      type: typeToAst(type.ofType),
+    };
+  } else {
+    return {
+      kind: Kind.NAMED_TYPE,
+      name: {
+        kind: Kind.NAME,
+        value: type.toString(),
+      },
+    };
+  }
+}
+
+function isObject(item: any): Boolean {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+function mergeDeep(target: any, source: any): any {
+  let output = Object.assign({}, target);
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key])) {
+        if (!(key in target)) {
+          Object.assign(output, { [key]: source[key] });
+        } else {
+          output[key] = mergeDeep(target[key], source[key]);
+        }
+      } else {
+        Object.assign(output, { [key]: source[key] });
+      }
+    });
+  }
+  return output;
+}
+
+function union(...arrays: Array<Array<string>>): Array<string> {
+  const cache: { [key: string]: Boolean } = {};
+  const result: Array<string> = [];
+  arrays.forEach(array => {
+    array.forEach(item => {
+      if (!cache[item]) {
+        cache[item] = true;
+        result.push(item);
+      }
+    });
+  });
+  return result;
+}
+
+function difference(
+  from: Array<string>,
+  ...arrays: Array<Array<string>>
+): Array<string> {
+  const cache: { [key: string]: Boolean } = {};
+  arrays.forEach(array => {
+    array.forEach(item => {
+      cache[item] = true;
+    });
+  });
+  return from.filter(item => !cache[item]);
+}

--- a/src/stitching/resolveFromParentTypename.ts
+++ b/src/stitching/resolveFromParentTypename.ts
@@ -1,0 +1,23 @@
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+
+export default function resolveFromParentTypename(
+  parent: any,
+  schema: GraphQLSchema,
+) {
+  const parentTypename: string = parent['__typename'];
+  if (!parentTypename) {
+    throw new Error(
+      'Did not fetch typename for object, unable to resolve interface.',
+    );
+  }
+
+  const resolvedType = schema.getType(parentTypename);
+
+  if (!(resolvedType instanceof GraphQLObjectType)) {
+    throw new Error(
+      '__typename did not match an object type: ' + parentTypename,
+    );
+  }
+
+  return resolvedType;
+}

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -47,6 +47,7 @@ const linkSchema = `
 
   extend type Query {
     delegateInterfaceTest: TestInterface
+    delegateArgumentTest(arbitraryArg: Int): Property
   }
 `;
 
@@ -110,6 +111,17 @@ testCombinations.forEach(async combination => {
                 'interfaceTest',
                 {
                   kind: 'ONE',
+                },
+                context,
+                info,
+              );
+            },
+            delegateArgumentTest(parent, args, context, info) {
+              return mergeInfo.delegate(
+                'query',
+                'propertyById',
+                {
+                  id: 'p1',
                 },
                 context,
                 info,
@@ -895,6 +907,29 @@ bookingById(id: $b1) {
                   },
                 },
               ],
+            },
+          },
+        });
+      });
+    });
+
+    describe('regression', () => {
+      it('should not pass extra arguments to delegates', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              delegateArgumentTest(arbitraryArg: 5) {
+                id
+              }
+            }
+          `,
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            delegateArgumentTest: {
+              id: 'p1',
             },
           },
         });

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -1,0 +1,904 @@
+/* tslint:disable:no-unused-expression */
+
+import { expect } from 'chai';
+import { graphql, GraphQLSchema, GraphQLScalarType } from 'graphql';
+import mergeSchemas from '../stitching/mergeSchemas';
+import {
+  propertySchema as localPropertySchema,
+  bookingSchema as localBookingSchema,
+  remoteBookingSchema,
+  remotePropertySchema,
+} from './testingSchemas';
+
+const testCombinations = [
+  { name: 'local', booking: localBookingSchema, property: localPropertySchema },
+  {
+    name: 'remote',
+    booking: remoteBookingSchema,
+    property: remotePropertySchema,
+  },
+  {
+    name: 'hybrid',
+    booking: localBookingSchema,
+    property: remotePropertySchema,
+  },
+];
+
+const scalarTest = `
+  scalar TestScalar
+
+  type TestingScalar {
+    value: TestScalar
+  }
+
+  type Query {
+    testingScalar: TestingScalar
+  }
+`;
+
+const linkSchema = `
+  extend type Booking {
+    property: Property
+  }
+
+  extend type Property {
+    bookings(limit: Int): [Booking]
+  }
+
+  extend type Query {
+    delegateInterfaceTest: TestInterface
+  }
+`;
+
+testCombinations.forEach(async combination => {
+  describe('merging ' + combination.name, () => {
+    let mergedSchema: GraphQLSchema,
+      propertySchema: GraphQLSchema,
+      bookingSchema: GraphQLSchema;
+
+    before(async () => {
+      propertySchema = await combination.property;
+      bookingSchema = await combination.booking;
+
+      mergedSchema = mergeSchemas({
+        schemas: [propertySchema, bookingSchema, scalarTest, linkSchema],
+        resolvers: mergeInfo => ({
+          TestScalar: new GraphQLScalarType({
+            name: 'TestScalar',
+            description: undefined,
+            serialize: value => value,
+            parseValue: value => value,
+            parseLiteral: () => null,
+          }),
+          Property: {
+            bookings: {
+              fragment: 'fragment PropertyFragment on Property { id }',
+              resolve(parent, args, context, info) {
+                return mergeInfo.delegate(
+                  'query',
+                  'bookingsByPropertyId',
+                  {
+                    propertyId: parent.id,
+                    limit: args.limit ? args.limit : null,
+                  },
+                  context,
+                  info,
+                );
+              },
+            },
+          },
+          Booking: {
+            property: {
+              fragment: 'fragment BookingFragment on Booking { propertyId }',
+              resolve(parent, args, context, info) {
+                return mergeInfo.delegate(
+                  'query',
+                  'propertyById',
+                  {
+                    id: parent.propertyId,
+                  },
+                  context,
+                  info,
+                );
+              },
+            },
+          },
+          Query: {
+            delegateInterfaceTest(parent, args, context, info) {
+              return mergeInfo.delegate(
+                'query',
+                'interfaceTest',
+                {
+                  kind: 'ONE',
+                },
+                context,
+                info,
+              );
+            },
+          },
+        }),
+      });
+    });
+
+    describe('basic', () => {
+      it('works with context', async () => {
+        const propertyResult = await graphql(
+          propertySchema,
+          `
+            query {
+              contextTest(key: "test")
+            }
+          `,
+          {},
+          {
+            test: 'Foo',
+          },
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              contextTest(key: "test")
+            }
+          `,
+          {},
+          {
+            test: 'Foo',
+          },
+        );
+
+        expect(propertyResult).to.deep.equal({
+          data: {
+            contextTest: '"Foo"',
+          },
+        });
+
+        expect(mergedResult).to.deep.equal(propertyResult);
+      });
+
+      it('works with custom scalars', async () => {
+        const propertyResult = await graphql(
+          propertySchema,
+          `
+            query {
+              dateTimeTest
+              test1: jsonTest(input: { foo: "bar" })
+              test2: jsonTest(input: 5)
+              test3: jsonTest(input: "6")
+            }
+          `,
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              dateTimeTest
+              test1: jsonTest(input: { foo: "bar" })
+              test2: jsonTest(input: 5)
+              test3: jsonTest(input: "6")
+            }
+          `,
+        );
+
+        expect(propertyResult).to.deep.equal({
+          data: {
+            dateTimeTest: '1987-09-25T12:00:00',
+            test1: { foo: 'bar' },
+            test2: 5,
+            test3: '6',
+          },
+        });
+        expect(mergedResult).to.deep.equal(propertyResult);
+      });
+
+      it('handles errors', async () => {
+        const propertyFragment = `
+          errorTest
+        `;
+        const bookingFragment = `
+bookingById(id: "b1") {
+  id
+  customer {
+    name
+  }
+  startTime
+  endTime
+}
+  `;
+
+        const propertyResult = await graphql(
+          propertySchema,
+          `query {
+            ${propertyFragment}
+          }`,
+        );
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          `query {
+            ${bookingFragment}
+          }`,
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `query {
+      ${propertyFragment}
+      ${bookingFragment}
+    }`,
+        );
+        expect(mergedResult).to.deep.equal({
+          errors: propertyResult.errors,
+          data: {
+            ...propertyResult.data,
+            ...bookingResult.data,
+          },
+        });
+
+        const mergedResult2 = await graphql(
+          mergedSchema,
+          `
+          query {
+            errorTestNonNull
+            ${bookingFragment}
+          }
+        `,
+        );
+
+        expect(mergedResult2).to.deep.equal({
+          errors: [
+            {
+              locations: [
+                {
+                  column: 13,
+                  line: 3,
+                },
+              ],
+              message: 'Sample error non-null!',
+              path: ['errorTestNonNull'],
+            },
+          ],
+          data: null,
+        });
+      });
+
+      it('queries', async () => {
+        const propertyFragment = `
+propertyById(id: "p1") {
+  id
+  name
+}
+  `;
+        const bookingFragment = `
+bookingById(id: "b1") {
+  id
+  customer {
+    name
+  }
+  startTime
+  endTime
+}
+  `;
+
+        const propertyResult = await graphql(
+          propertySchema,
+          `query { ${propertyFragment} }`,
+        );
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          `query { ${bookingFragment} }`,
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `query {
+      ${propertyFragment}
+      ${bookingFragment}
+    }`,
+        );
+        expect(mergedResult).to.deep.equal({
+          data: {
+            ...propertyResult.data,
+            ...bookingResult.data,
+          },
+        });
+      });
+
+      // Technically mutations are not idempotent, but they are in our test schemas
+      it('mutations', async () => {
+        const mutationFragment = `
+      mutation Mutation($input: BookingInput!) {
+        addBooking(input: $input) {
+          id
+          customer {
+            name
+          }
+          startTime
+          endTime
+        }
+      }
+    `;
+        const input = {
+          propertyId: 'p1',
+          customerId: 'c1',
+          startTime: '2015-01-10',
+          endTime: '2015-02-10',
+        };
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          mutationFragment,
+          {},
+          {},
+          {
+            input,
+          },
+        );
+        const mergedResult = await graphql(
+          mergedSchema,
+          mutationFragment,
+          {},
+          {},
+          {
+            input,
+          },
+        );
+
+        expect(mergedResult).to.deep.equal(bookingResult);
+      });
+
+      it('links in queries', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              firstProperty: propertyById(id: "p2") {
+                id
+                name
+                bookings {
+                  id
+                  customer {
+                    name
+                  }
+                }
+              }
+              secondProperty: propertyById(id: "p3") {
+                id
+                name
+                bookings {
+                  id
+                  customer {
+                    name
+                  }
+                }
+              }
+              booking: bookingById(id: "b1") {
+                id
+                customer {
+                  name
+                }
+                property {
+                  id
+                  name
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            firstProperty: {
+              id: 'p2',
+              name: 'Another great hotel',
+              bookings: [
+                {
+                  id: 'b4',
+                  customer: {
+                    name: 'Exampler Customer',
+                  },
+                },
+              ],
+            },
+            secondProperty: {
+              id: 'p3',
+              name: 'BedBugs - The Affordable Hostel',
+              bookings: [],
+            },
+            booking: {
+              id: 'b1',
+              customer: {
+                name: 'Exampler Customer',
+              },
+
+              property: {
+                id: 'p1',
+                name: 'Super great hotel',
+              },
+            },
+          },
+        });
+      });
+
+      it('interfaces', async () => {
+        const query = `
+          query {
+            test1: interfaceTest(kind: ONE) {
+              __typename
+              kind
+              testString
+              ...on TestImpl1 {
+                foo
+              }
+              ...on TestImpl2 {
+                bar
+              }
+            }
+
+            test2: interfaceTest(kind: TWO) {
+              __typename
+              kind
+              testString
+              ...on TestImpl1 {
+                foo
+              }
+              ...on TestImpl2 {
+                bar
+              }
+            }
+          }
+        `;
+        const propertyResult = await graphql(propertySchema, query);
+        const mergedResult = await graphql(mergedSchema, query);
+
+        expect(propertyResult).to.deep.equal({
+          data: {
+            test1: {
+              __typename: 'TestImpl1',
+              kind: 'ONE',
+              testString: 'test',
+              foo: 'foo',
+            },
+            test2: {
+              __typename: 'TestImpl2',
+              kind: 'TWO',
+              testString: 'test',
+              bar: 'bar',
+            },
+          },
+        });
+
+        expect(mergedResult).to.deep.equal(propertyResult);
+
+        const delegateQuery = `
+          query {
+            withTypeName: delegateInterfaceTest {
+              __typename
+              kind
+              testString
+            }
+            withoutTypeName: delegateInterfaceTest {
+              kind
+              testString
+            }
+          }
+        `;
+
+        const mergedDelegate = await graphql(mergedSchema, delegateQuery);
+
+        expect(mergedDelegate).to.deep.equal({
+          data: {
+            withTypeName: {
+              __typename: 'TestImpl1',
+              kind: 'ONE',
+              testString: 'test',
+            },
+            withoutTypeName: {
+              kind: 'ONE',
+              testString: 'test',
+            },
+          },
+        });
+      });
+
+      it('unions', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              customerById(id: "c1") {
+                ... on Person {
+                  name
+                }
+                vehicle {
+                  ... on Bike {
+                    bikeType
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            customerById: {
+              name: 'Exampler Customer',
+              vehicle: { bikeType: 'MOUNTAIN' },
+            },
+          },
+        });
+      });
+
+      it('deep links', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              propertyById(id: "p2") {
+                id
+                name
+                bookings {
+                  id
+                  customer {
+                    name
+                  }
+                  property {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            propertyById: {
+              id: 'p2',
+              name: 'Another great hotel',
+              bookings: [
+                {
+                  id: 'b4',
+                  customer: {
+                    name: 'Exampler Customer',
+                  },
+                  property: {
+                    id: 'p2',
+                    name: 'Another great hotel',
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+
+      it('link arguments', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              propertyById(id: "p1") {
+                id
+                name
+                bookings(limit: 1) {
+                  id
+                  customer {
+                    name
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            propertyById: {
+              id: 'p1',
+              name: 'Super great hotel',
+              bookings: [
+                {
+                  id: 'b1',
+                  customer: {
+                    name: 'Exampler Customer',
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+    });
+
+    describe('fragments', () => {
+      it('named', async () => {
+        const propertyFragment = `
+fragment PropertyFragment on Property {
+  id
+  name
+  location {
+    name
+  }
+}
+    `;
+        const bookingFragment = `
+fragment BookingFragment on Booking {
+  id
+  customer {
+    name
+  }
+  startTime
+  endTime
+}
+    `;
+
+        const propertyResult = await graphql(
+          propertySchema,
+          `
+          ${propertyFragment}
+            query {
+              propertyById(id: "p1") {
+                ...PropertyFragment
+              }
+            }
+          `,
+        );
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          `
+            ${bookingFragment}
+            query {
+              bookingById(id: "b1") {
+                ...BookingFragment
+              }
+            }
+          `,
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+          ${bookingFragment}
+          ${propertyFragment}
+
+            query {
+              propertyById(id: "p1") {
+                ...PropertyFragment
+              }
+              bookingById(id: "b1") {
+                ...BookingFragment
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            ...propertyResult.data,
+            ...bookingResult.data,
+          },
+        });
+      });
+
+      it('inline', async () => {
+        const propertyFragment = `
+propertyById(id: "p1") {
+  ... on Property {
+    id
+  }
+  name
+}
+  `;
+        const bookingFragment = `
+bookingById(id: "b1") {
+  id
+  ... on Booking {
+    customer {
+      name
+    }
+    startTime
+    endTime
+  }
+}
+  `;
+
+        const propertyResult = await graphql(
+          propertySchema,
+          `query { ${propertyFragment} }`,
+        );
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          `query { ${bookingFragment} }`,
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `query {
+      ${propertyFragment}
+      ${bookingFragment}
+    }`,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            ...propertyResult.data,
+            ...bookingResult.data,
+          },
+        });
+      });
+
+      it('containing links', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              propertyById(id: "p2") {
+                id
+                ... on Property {
+                  name
+                  bookings {
+                    id
+                    customer {
+                      name
+                    }
+                    ...BookingFragment
+                  }
+                }
+              }
+            }
+
+            fragment BookingFragment on Booking {
+              property {
+                ...PropertyFragment
+              }
+            }
+
+            fragment PropertyFragment on Property {
+              id
+              name
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            propertyById: {
+              id: 'p2',
+              name: 'Another great hotel',
+              bookings: [
+                {
+                  id: 'b4',
+                  customer: {
+                    name: 'Exampler Customer',
+                  },
+                  property: {
+                    id: 'p2',
+                    name: 'Another great hotel',
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+    });
+
+    describe('variables', () => {
+      it('basic', async () => {
+        const propertyFragment = `
+propertyById(id: $p1) {
+  id
+  name
+}
+  `;
+        const bookingFragment = `
+bookingById(id: $b1) {
+  id
+  customer {
+    name
+  }
+  startTime
+  endTime
+}
+  `;
+
+        const propertyResult = await graphql(
+          propertySchema,
+          `query($p1: ID!) { ${propertyFragment} }`,
+          {},
+          {},
+          {
+            p1: 'p1',
+          },
+        );
+
+        const bookingResult = await graphql(
+          bookingSchema,
+          `query($b1: ID!) { ${bookingFragment} }`,
+          {},
+          {},
+          {
+            b1: 'b1',
+          },
+        );
+
+        const mergedResult = await graphql(
+          mergedSchema,
+          `query($p1: ID!, $b1: ID!) {
+        ${propertyFragment}
+        ${bookingFragment}
+      }`,
+          {},
+          {},
+          {
+            p1: 'p1',
+            b1: 'b1',
+          },
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            ...propertyResult.data,
+            ...bookingResult.data,
+          },
+        });
+      });
+
+      it('in link selections', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query($limit: Int) {
+              propertyById(id: "p1") {
+                id
+                name
+                ... on Property {
+                  bookings(limit: $limit) {
+                    id
+                    customer {
+                      name
+                      ... on Person {
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `,
+          {},
+          {},
+          {
+            limit: 1,
+          },
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            propertyById: {
+              id: 'p1',
+              name: 'Super great hotel',
+              bookings: [
+                {
+                  id: 'b1',
+                  customer: {
+                    name: 'Exampler Customer',
+                    id: 'c1',
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+    });
+  });
+});

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -1,0 +1,498 @@
+import {
+  GraphQLSchema,
+  graphql,
+  Kind,
+  GraphQLScalarType,
+  ValueNode,
+} from 'graphql';
+import { makeExecutableSchema } from '../schemaGenerator';
+import { IResolvers } from '../Interfaces';
+import makeRemoteExecutableSchema from '../stitching/makeRemoteExecutableSchema';
+import introspectSchema from '../stitching/introspectSchema';
+import { Fetcher } from '../stitching/makeRemoteExecutableSchema';
+
+export type Property = {
+  id: string;
+  name: string;
+  location: {
+    name: string;
+  };
+};
+
+export type Booking = {
+  id: string;
+  propertyId: string;
+  customerId: string;
+  startTime: string;
+  endTime: string;
+};
+
+export type Customer = {
+  id: string;
+  email: string;
+  name: string;
+  address?: string;
+  vehicleId?: string;
+};
+
+export type Vehicle = {
+  id: string;
+  licensePlate?: string;
+  bikeType?: 'MOUNTAIN' | 'ROAD';
+};
+
+export const sampleData: {
+  Property: { [key: string]: Property };
+  Booking: { [key: string]: Booking };
+  Customer: { [key: string]: Customer };
+  Vehicle: { [key: string]: Vehicle };
+} = {
+  Property: {
+    p1: {
+      id: 'p1',
+      name: 'Super great hotel',
+      location: {
+        name: 'Helsinki',
+      },
+    },
+    p2: {
+      id: 'p2',
+      name: 'Another great hotel',
+      location: {
+        name: 'San Francisco',
+      },
+    },
+    p3: {
+      id: 'p3',
+      name: 'BedBugs - The Affordable Hostel',
+      location: {
+        name: 'Helsinki',
+      },
+    },
+  },
+  Booking: {
+    b1: {
+      id: 'b1',
+      propertyId: 'p1',
+      customerId: 'c1',
+      startTime: '2016-05-04',
+      endTime: '2016-06-03',
+    },
+    b2: {
+      id: 'b2',
+      propertyId: 'p1',
+      customerId: 'c2',
+      startTime: '2016-06-04',
+      endTime: '2016-07-03',
+    },
+    b3: {
+      id: 'b3',
+      propertyId: 'p1',
+      customerId: 'c3',
+      startTime: '2016-08-04',
+      endTime: '2016-09-03',
+    },
+    b4: {
+      id: 'b4',
+      propertyId: 'p2',
+      customerId: 'c1',
+      startTime: '2016-10-04',
+      endTime: '2016-10-03',
+    },
+  },
+
+  Customer: {
+    c1: {
+      id: 'c1',
+      email: 'examplec1@example.com',
+      name: 'Exampler Customer',
+      vehicleId: 'v1',
+    },
+    c2: {
+      id: 'c2',
+      email: 'examplec2@example.com',
+      name: 'Joe Doe',
+      vehicleId: 'v2',
+    },
+    c3: {
+      id: 'c3',
+      email: 'examplec3@example.com',
+      name: 'Liisa Esimerki',
+      address: 'Esimerkikatu 1 A 77, 99999 Kyyjarvi',
+    },
+  },
+
+  Vehicle: {
+    v1: {
+      id: 'v1',
+      bikeType: 'MOUNTAIN',
+    },
+    v2: {
+      id: 'v2',
+      licensePlate: 'GRAPHQL',
+    },
+  },
+};
+
+function values<T>(o: { [s: string]: T }): T[] {
+  return Object.keys(o).map(k => o[k]);
+}
+
+function coerceString(value: any): string {
+  if (Array.isArray(value)) {
+    throw new TypeError(
+      `String cannot represent an array value: [${String(value)}]`,
+    );
+  }
+  return String(value);
+}
+
+const DateTime = new GraphQLScalarType({
+  name: 'DateTime',
+  description: 'Simple fake datetime',
+  serialize: coerceString,
+  parseValue: coerceString,
+  parseLiteral(ast) {
+    return ast.kind === Kind.STRING ? ast.value : null;
+  },
+});
+
+function identity(value: any): any {
+  return value;
+}
+
+function parseLiteral(ast: ValueNode): any {
+  switch (ast.kind) {
+    case Kind.STRING:
+    case Kind.BOOLEAN:
+      return ast.value;
+    case Kind.INT:
+    case Kind.FLOAT:
+      return parseFloat(ast.value);
+    case Kind.OBJECT: {
+      const value = Object.create(null);
+      ast.fields.forEach(field => {
+        value[field.name.value] = parseLiteral(field.value);
+      });
+
+      return value;
+    }
+    case Kind.LIST:
+      return ast.values.map(parseLiteral);
+    default:
+      return null;
+  }
+}
+
+const GraphQLJSON = new GraphQLScalarType({
+  name: 'JSON',
+  description:
+    'The `JSON` scalar type represents JSON values as specified by ' +
+    '[ECMA-404](http://www.ecma-international.org/' +
+    'publications/files/ECMA-ST/ECMA-404.pdf).',
+  serialize: identity,
+  parseValue: identity,
+  parseLiteral,
+});
+
+const addressTypeDef = `
+  type Address {
+    street: String
+    city: String
+    state: String
+    zip: String
+  }
+`;
+
+const propertyAddressTypeDef = `
+  type Property {
+    id: ID!
+    name: String!
+    location: Location
+    address: Address
+  }
+`;
+
+const propertyRootTypeDefs = `
+  type Location {
+    name: String!
+  }
+
+  enum TestInterfaceKind {
+    ONE
+    TWO
+  }
+
+  interface TestInterface {
+    kind: TestInterfaceKind
+    testString: String
+  }
+
+  type TestImpl1 implements TestInterface {
+    kind: TestInterfaceKind
+    testString: String
+    foo: String
+  }
+
+  type TestImpl2 implements TestInterface {
+    kind: TestInterfaceKind
+    testString: String
+    bar: String
+  }
+
+  type Query {
+    propertyById(id: ID!): Property
+    properties(limit: Int): [Property!]
+    contextTest(key: String!): String
+    dateTimeTest: DateTime
+    jsonTest(input: JSON): JSON
+    interfaceTest(kind: TestInterfaceKind): TestInterface
+    errorTest: String
+    errorTestNonNull: String!
+  }
+`;
+
+const propertyAddressTypeDefs = `
+  scalar DateTime
+  scalar JSON
+
+  ${addressTypeDef}
+  ${propertyAddressTypeDef}
+  ${propertyRootTypeDefs}
+`;
+
+const propertyResolvers: IResolvers = {
+  Query: {
+    propertyById(root, { id }) {
+      return sampleData.Property[id];
+    },
+
+    properties(root, { limit }) {
+      const list = values(sampleData.Property);
+      if (limit) {
+        return list.slice(0, limit);
+      } else {
+        return list;
+      }
+    },
+
+    contextTest(root, args, context) {
+      return JSON.stringify(context[args.key]);
+    },
+
+    dateTimeTest() {
+      return '1987-09-25T12:00:00';
+    },
+
+    jsonTest(root, { input }) {
+      return input;
+    },
+
+    interfaceTest(root, { kind }) {
+      if (kind === 'ONE') {
+        return {
+          kind: 'ONE',
+          testString: 'test',
+          foo: 'foo',
+        };
+      } else {
+        return {
+          kind: 'TWO',
+          testString: 'test',
+          bar: 'bar',
+        };
+      }
+    },
+
+    errorTest() {
+      throw new Error('Sample error!');
+    },
+
+    errorTestNonNull() {
+      throw new Error('Sample error non-null!');
+    },
+  },
+  DateTime,
+  JSON: GraphQLJSON,
+
+  TestInterface: {
+    __resolveType(obj) {
+      if (obj.kind === 'ONE') {
+        return 'TestImpl1';
+      } else {
+        return 'TestImpl2';
+      }
+    },
+  },
+};
+
+const customerAddressTypeDef = `
+  type Customer implements Person {
+    id: ID!
+    email: String!
+    name: String!
+    address: Address
+    bookings(limit: Int): [Booking!]
+    vehicle: Vehicle
+  }
+`;
+
+const bookingRootTypeDefs = `
+  scalar DateTime
+
+  type Booking {
+    id: ID!
+    propertyId: ID!
+    customer: Customer!
+    startTime: String!
+    endTime: String!
+  }
+
+  interface Person {
+    id: ID!
+    name: String!
+  }
+
+  union Vehicle = Bike | Car
+
+  type Bike {
+    id: ID!
+    bikeType: String
+  }
+
+  type Car {
+    id: ID!
+    licensePlate: String
+  }
+
+  type Query {
+    bookingById(id: ID!): Booking
+    bookingsByPropertyId(propertyId: ID!, limit: Int): [Booking!]
+    customerById(id: ID!): Customer
+    bookings(limit: Int): [Booking!]
+    customers(limit: Int): [Customer!]
+  }
+
+  input BookingInput {
+    propertyId: ID!
+    customerId: ID!
+    startTime: DateTime!
+    endTime: DateTime!
+  }
+
+  type Mutation {
+    addBooking(input: BookingInput): Booking
+  }
+`;
+
+const bookingAddressTypeDefs = `
+  ${addressTypeDef}
+  ${customerAddressTypeDef}
+  ${bookingRootTypeDefs}
+`;
+
+const bookingResolvers: IResolvers = {
+  Query: {
+    bookingById(parent, { id }) {
+      return sampleData.Booking[id];
+    },
+    bookingsByPropertyId(parent, { propertyId, limit }) {
+      const list = values(sampleData.Booking).filter(
+        (booking: Booking) => booking.propertyId === propertyId,
+      );
+      if (limit) {
+        return list.slice(0, limit);
+      } else {
+        return list;
+      }
+    },
+    customerById(parent, { id }) {
+      return sampleData.Customer[id];
+    },
+    bookings(parent, { limit }) {
+      const list = values(sampleData.Booking);
+      if (limit) {
+        return list.slice(0, limit);
+      } else {
+        return list;
+      }
+    },
+    customers(parent, { limit }) {
+      const list = values(sampleData.Customer);
+      if (limit) {
+        return list.slice(0, limit);
+      } else {
+        return list;
+      }
+    },
+  },
+
+  Mutation: {
+    addBooking(
+      parent,
+      { input: { propertyId, customerId, startTime, endTime } },
+    ) {
+      return {
+        id: 'newId',
+        propertyId,
+        customerId,
+        startTime,
+        endTime,
+      };
+    },
+  },
+
+  Booking: {
+    customer(parent: Booking) {
+      return sampleData.Customer[parent.customerId];
+    },
+  },
+
+  Customer: {
+    bookings(parent: Customer) {
+      return values(sampleData.Booking).filter(
+        (booking: Booking) => booking.customerId === parent.id,
+      );
+    },
+    vehicle(parent: Customer) {
+      return sampleData.Vehicle[parent.vehicleId];
+    },
+  },
+
+  Vehicle: {
+    __resolveType(parent) {
+      if (parent.licensePlate) {
+        return 'Car';
+      } else if (parent.bikeType) {
+        return 'Bike';
+      } else {
+        throw new Error('Could not resolve Vehicle type');
+      }
+    },
+  },
+
+  DateTime,
+};
+
+export const propertySchema: GraphQLSchema = makeExecutableSchema({
+  typeDefs: propertyAddressTypeDefs,
+  resolvers: propertyResolvers,
+});
+
+export const bookingSchema: GraphQLSchema = makeExecutableSchema({
+  typeDefs: bookingAddressTypeDefs,
+  resolvers: bookingResolvers,
+});
+
+// Pretend this schema is remote
+async function makeSchemaRemote(schema: GraphQLSchema) {
+  const fetcher: Fetcher = ({ query, operationName, variables, context }) => {
+    return graphql(schema, query, null, context, variables, operationName);
+  };
+
+  const clientSchema = await introspectSchema(fetcher);
+  return makeRemoteExecutableSchema({ schema: clientSchema, fetcher });
+}
+
+export const remotePropertySchema = makeSchemaRemote(propertySchema);
+export const remoteBookingSchema = makeSchemaRemote(bookingSchema);

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -4,3 +4,4 @@ import './testSchemaGenerator';
 import './testLogger';
 import './testMocking';
 import './testResolution';
+import './testMergeSchemas';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,19 @@
 {
-	"compilerOptions": {
-		"experimentalDecorators": true,
-		"lib": ["es6", "dom", "esnext.asynciterable"],
-		"module": "commonjs",
-		"target": "es5",
-		"noImplicitAny": true,
-		"suppressImplicitAnyIndexErrors": true,
-		"moduleResolution": "node",
-		"emitDecoratorMetadata": true,
-		"noUnusedLocals": true,
-		"sourceMap": true,
-		"declaration": true,
-		"rootDir": "./src",
-		"outDir": "./dist",
-		"removeComments": false
-	},
-	"exclude": [
-		"node_modules",
-    "dist"
-	]
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "lib": ["es7", "dom", "esnext.asynciterable"],
+    "module": "commonjs",
+    "target": "es5",
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "noUnusedLocals": true,
+    "sourceMap": true,
+    "declaration": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "removeComments": false
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This is a WIP take on schema-stiching and schema merging. This will be published to a pre-release tag. See `src/test/testingSchemas.js` for examples..

## API

<h3 id="makeRemoteExecutableSchema" title="makeRemoteExecutableSchema">
  makeRemoteExecutableSchema({ schema: GraphQLSchema, fetcher: Fetcher }): GraphQLSchema
</h3>

Given a GraphQL schema (can be a non-executable client schema made by `buildClientSchema`) and a [Fetcher](#Fetcher), produce a GraphQL Schema that routes all requests to the fetcher.

<h3 id="introspectSchema" title="introspectSchema">
  introspectSchema(
    fetcher: Fetcher,
    context?: {[key: string]: any}
): Promise&lt;GraphQLSchema&gt;</h3>

Use fetcher to build a client schema using introspection query. For easy of use of `makeRemoteExecutableSchema`. Provides a *client* schema, so a non-executable schema. Accepts optional second argument `context`, which is passed to the fetcher.

<h3 id="Fetcher" title="Fetcher">
  Fetcher
</h3>

```js
type Fetcher = (
  operation: {
    query: string;
    operationName?: string;
    variables?: { [key: string]: any };
    context?: { [key: string]: any };
  },
) => Promise<ExecutionResult>;
```

#### Usage with [apollo-link](https://github.com/apollographql/apollo-link)

```js
import { HttpLink, makePromise, execute } from 'apollo-link';

const link = new HttpLink({ uri: 'http://api.githunt.com/graphql' });
const fetcher = (operation) => makePromise(execute(link, operation));
const schema = makeRemoteExecutableSchema({
  schema: await introspectSchema(fetcher),
  fetcher,
});
```

#### Usage with [apollo-fetch](https://github.com/apollographql/apollo-fetch)

```js
import { createApolloFetch } from 'apollo-fetch';

const apolloFetch = createApolloFetch({ uri: 'http://api.githunt.com/graphql'});
const fetcher = ({ query, variables, operationName, context}) => apolloFetch({
  query, variables, operationName
});
const schema = makeRemoteExecutableSchema({
  schema: await introspectSchema(fetcher),
  fetcher,
});
```

#### Usage with a generic HTTP client (like node-fetch)

```js
import fetch from 'node-fetch';

const fetcher = async ({ query, variables, operationName, context }) => {
  const fetchResult = fetch('http://api.githunt.com/graphql', {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
    },
    body: JSON.stringify({ query, variables, operationName })
  });
  return fetchResult.json();
};
const schema = makeRemoteExecutableSchema({
  schema: await introspectSchema(fetcher),
  fetcher,
});
```
 
### mergeSchemas

```
mergeSchemas({
  schemas: Array<GraphQLSchema | string>,
  resolvers?: (mergeInfo: MergeInfo) => IResolvers,
  onTypeConflict?: (
    left: GraphQLNamedType,
    right: GraphQLNamedType
  ) => GraphQLNamedType
})

type MergeInfo = {
  delegate(
    operation: 'query' | 'mutation',
    rootFieldName: string,
    args: any,
    context: any,
    info: GraphQLResolveInfo
  ) => any
}
```

#### schemas

`schemas` can be both `GraphQLSchema` (but it has to be an executable schema) or strings. In case they are strings only extensions (`extend type`) will be used. Passing strings is useful to add fields to existing types to link schemas together.

#### resolvers

`resolvers` is an optional a function that takes one argument - `mergeInfo` and
returns resolvers in [makeExecutableSchema](./resolvers.html) format.

#### mergeInfo and delegate

`mergeInfo` currenty is an object with one propeprty - `delegate`.

`delegate` takes operation and root field names, together with GraphQL context
and resolve info, as well as arguments for the root field. It forwards query to
one of the merged schema and makes sure that only relevant fields are requested.

```js
mergeInfo.delegate(
  'query',
  'propertyById',
  {
    id: parent.id,
  },
  context,
  info,
);
```

#### onTypeConflict

`onTypeConflict` lets you customize type resolving logic. Default logic is to
take the first encountered type of all the types with the same name. This
methods allows customization of this, for example by taking other type or
merging types together.

## Example

```js
import {
  makeRemoteExecutableSchema,
  introspectSchema,
  mergeSchemas,
} from 'graphql-tools';
import { HttpLink, execute, makePromise } from 'apollo-link';

async function makeMergedSchema() {
  // Create remote executable schemas
  const PropertyLink = new HttpLink({
    uri: 'https://v7l45qkw3.lp.gql.zone/graphql',
  });
  const PropertyFetcher = operation =>
    makePromise(execute(PropertyLink, operation));
  const PropertySchema = makeRemoteExecutableSchema({
    schema: await introspectSchema(PropertyFetcher),
    fetcher: PropertyFetcher,
  });

  const BookingLink = new HttpLink({
    uri: 'https://41p4j4309.lp.gql.zone/graphql',
  });
  const BookingFetcher = operation =>
    makePromise(execute(BookingLink, operation));
  const PropertySchema = makeRemoteExecutableSchema({
    schema: await introspectSchema(BookingFetcher),
    fetcher: BookingFetcher,
  });

  // A small string schema extensions to add links between schemas
  const LinkSchema = `
    extend type Booking {
      property: Property
    }

    extend type Property {
      bookings(limit: Int): [Booking]
    }
  `;

  // merge actual schema
  const mergedSchema = mergeSchemas({
    schemas: [PropertySchema, BookingSchema, LinkSchema],
    // Define resolvers manually for links
    resolvers: mergeInfo => ({
      Property: {
        bookings: {
          fragment: 'fragment PropertyFragment on Property { id }',
          resolve(parent, args, context, info) {
            return mergeInfo.delegate(
              'query',
              'bookingsByPropertyId',
              {
                propertyId: parent.id,
                limit: args.limit ? args.limit : null,
              },
              context,
              info,
            );
          },
        },
      },
      Booking: {
        property: {
          fragment: 'fragment BookingFragment on Booking { propertyId }',
          resolve(parent, args, context, info) {
            return mergeInfo.delegate(
              'query',
              'propertyById',
              {
                id: parent.propertyId,
              },
              context,
              info,
            );
          },
        },
      },
    }),
  });

  return mergedSchema;
}
```

# Known issues

- [x] Unions and interfaces don't work on remote schemas
- [ ] Unions and interfaces don't work with remote schemas unless __typename is passed. However in mergedSchema it is done already, just need to figure out how to port it.
- [x] New lower level API that will allow handling links by just defining resolvers
- [x] Better default solution for remote custom scalars, currently they break eg JSON.
- [x] Make sure that aliases work
- [x] Types that only implement interfaces are missing
- [x] Better error handling - handle non fatal errros, make sure errors propagate from sub schemas, optional imperative interface to deal with errors from delegate.
- [x] Optional arguments in root fields don't work as expected when using delegate (and are basically ignored)
- [ ] Generate var names in a more sane way, currently we just do _${argName}.
- [ ] Figuring out if we want to add namespacing transform for schema

# Production ready checklist

- [x] Documentation
- [ ] Example app(s)
- [ ] Blog post / announcement
- [x] Get rid of lodash and other extra deps
- [x] Validate usage in production for several people
- [x] Move all tests to not use .to.not.be.undefined, really hard to debug. use .to.deep.equal for full response
