### PR TITLE
[schema-stitching]: Skip iterating fields on GraphQLScalarType

### DIFF
--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -34,6 +34,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLResolveInfo,
+  GraphQLScalarType,
   GraphQLSchema,
   GraphQLType,
   GraphQLUnionType,
@@ -173,6 +174,9 @@ export default function mergeSchemas({
   const passedResolvers = resolvers(mergeInfo);
 
   forEach(passedResolvers, (type, typeName) => {
+    if (type instanceof GraphQLScalarType) {
+      return;
+    }
     forEach(type, (field, fieldName) => {
       if (field.fragment) {
         typeRegistry.addFragment(typeName, fieldName, field.fragment);


### PR DESCRIPTION
If the local resolvers contain a `GraphQLScalarType`, the check for `field.fragment` will cause an error with `cannot read property fragment of undefined`, since it's iterating over the object `GraphQLScalarType` properties. Not sure if there'd be other types where this could be an issue.

Another interesting observation when writing the test case, if I added:

```
scalar TestScalar

type TestingScalar {
  value: TestScalar
}
```
without the root query, and add that to the list of merged schemas it's silently ignored by the try/catch [`here`](https://github.com/apollographql/graphql-tools/blob/a76cfae4fa17bb8d723fc2f70ad821a9cccd1e2f/src/stitching/mergeSchemas.ts#L106-L108) since the schema doesn't have a `Query` and therefore isn't valid on its own. Since it didn't have any extensions, it apparently doesn't doing anything - not sure if this is a situation anyone would run into but thought it was worth mentioning.