### PR TITLE
[schema-stitching]: __typename fixes

### DIFF
--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -260,7 +260,7 @@ function recreateCompositeType(
       fields: () => inputFieldMapToFieldConfigMap(type.getFields(), registry),
     });
   } else {
-    throw new Error('Invalid type ${type.name}');
+    throw new Error(`Invalid type ${type.name}`);
   }
 }
 
@@ -333,7 +333,7 @@ function createMergeInfo(typeRegistry: TypeRegistry): MergeInfo {
       const schema = typeRegistry.getSchemaByField(operation, fieldName);
       if (!schema) {
         throw new Error(
-          'Cannot find subschema for root field `${operation}.${fieldName}`',
+          `Cannot find subschema for root field ${operation}.${fieldName}`,
         );
       }
       const fragmentReplacements = typeRegistry.fragmentReplacements;

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -43,6 +43,7 @@ import {
   OperationDefinitionNode,
   SelectionSetNode,
   TypeNode,
+  TypeNameMetaFieldDef,
   VariableDefinitionNode,
   VariableNode,
   buildASTSchema,
@@ -694,7 +695,9 @@ function filterSelectionSet(
           parentType instanceof GraphQLInterfaceType
         ) {
           const fields = parentType.getFields();
-          const field = fields[node.name.value];
+          const field = node.name.value === '__typename'
+            ? TypeNameMetaFieldDef
+            : fields[node.name.value];
           if (!field) {
             const fragment =
               fragmentReplacements[parentType.name] &&

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -716,6 +716,24 @@ function filterSelectionSet(
         typeStack.pop();
       },
     },
+    [Kind.SELECTION_SET](node: SelectionSetNode): SelectionSetNode | null | undefined {
+      const parentType: GraphQLType = resolveType(
+        typeStack[typeStack.length - 1],
+      );
+      if (parentType instanceof GraphQLInterfaceType || parentType instanceof GraphQLUnionType) {
+        return {
+          ...node,
+          selections: node.selections.concat({
+            kind: Kind.FIELD,
+            name: {
+              kind: Kind.NAME,
+              value: '__typename'
+            }
+          }
+         )
+        };
+      }
+    },
     [Kind.FRAGMENT_SPREAD](node: FragmentSpreadNode): null | undefined {
       if (validFragments.includes(node.name.value)) {
         usedFragments.push(node.name.value);

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -260,7 +260,7 @@ function recreateCompositeType(
       fields: () => inputFieldMapToFieldConfigMap(type.getFields(), registry),
     });
   } else {
-    throw new Error(`Invalid type ${type.name}`);
+    throw new Error(`Invalid type ${type}`);
   }
 }
 


### PR DESCRIPTION
I was running into an issue where `__typename` was being stripped out in `filterSelectionSet ` on delegated requests. Also I believe this should automatically add `__typename` on all interface/requests to execute. Still needs tests, but the existing suite is passing.

Prior to this change I was getting `Did not fetch typename for object, unable to resolve interface.` when it was definitely there in the request/parsed documentAST passed through to the `mergeInfo.resolve`