### PR TITLE
added native support for using apollo-link as the network layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change log
 
 ### vNEXT
+* Added support for passing an Apollo Link instead of a fetcher
 
 ### v2.0.0
-
 * Add schema merging utilities [PR #382](https://github.com/apollographql/graphql-tools/pull/382)
 
 ### v1.2.3

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
+    "apollo-link": "^0.7.0",
     "deprecated-decorator": "^0.1.6",
     "uuid": "^3.1.0"
   },

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -3,6 +3,8 @@ import { introspectionQuery, buildClientSchema } from 'graphql';
 import { ApolloLink, execute, makePromise } from 'apollo-link';
 import { Fetcher, fetcherToLink } from './makeRemoteExecutableSchema';
 
+const parsedIntrospectionQuery = parse(introspectionQuery);
+
 export default async function introspectSchema(
   link: ApolloLink | Fetcher,
   context?: { [key: string]: any },
@@ -10,10 +12,12 @@ export default async function introspectSchema(
   if (!(link as ApolloLink).request) {
     link = fetcherToLink(link as Fetcher);
   }
-  const introspectionResult = await makePromise(execute((link as ApolloLink), {
-    query: typeof introspectionQuery === 'string' ? parse(introspectionQuery) : introspectionQuery,
-    context,
-  }));
+  const introspectionResult = await makePromise(
+    execute(link as ApolloLink, {
+      query: parsedIntrospectionQuery,
+      context,
+    }),
+  );
   if (introspectionResult.errors || !introspectionResult.data.__schema) {
     throw introspectionResult.errors;
   } else {

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -1,15 +1,19 @@
-import { GraphQLSchema } from 'graphql';
+import { GraphQLSchema, parse } from 'graphql';
 import { introspectionQuery, buildClientSchema } from 'graphql';
-import { Fetcher } from './makeRemoteExecutableSchema';
+import { ApolloLink, execute, makePromise } from 'apollo-link';
+import { Fetcher, fetcherToLink } from './makeRemoteExecutableSchema';
 
 export default async function introspectSchema(
-  fetcher: Fetcher,
+  link: ApolloLink | Fetcher,
   context?: { [key: string]: any },
 ): Promise<GraphQLSchema> {
-  const introspectionResult = await fetcher({
-    query: introspectionQuery,
+  if (!(link as ApolloLink).request) {
+    link = fetcherToLink(link as Fetcher);
+  }
+  const introspectionResult = await makePromise(execute((link as ApolloLink), {
+    query: typeof introspectionQuery === 'string' ? parse(introspectionQuery) : introspectionQuery,
     context,
-  });
+  }));
   if (introspectionResult.errors || !introspectionResult.data.__schema) {
     throw introspectionResult.errors;
   } else {

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -1,4 +1,6 @@
-import { printSchema, print, ExecutionResult, Kind, ValueNode } from 'graphql';
+import { printSchema, print, parse, Kind, ValueNode, ExecutionResult } from 'graphql';
+import { execute, makePromise, ApolloLink, Observable } from 'apollo-link';
+
 import {
   GraphQLFieldResolver,
   GraphQLSchema,
@@ -25,25 +27,51 @@ export type Fetcher = (
   },
 ) => Promise<ExecutionResult>;
 
+export const fetcherToLink = (fetcher: Fetcher): ApolloLink => {
+  return new ApolloLink((operation) => {
+    return new Observable(observer => {
+      const { query, operationName, variables } = operation;
+      const context = operation.getContext();
+      fetcher({
+        query: typeof query === 'string' ? query : print(query),
+        operationName,
+        variables,
+        context
+      })
+        .then((result: ExecutionResult) => {
+          observer.next(result);
+          observer.complete();
+        })
+        .catch(observer.error.bind(observer));
+    });
+  });
+};
+
 export default function makeRemoteExecutableSchema({
   schema,
-  fetcher,
+  link,
+  fetcher
 }: {
   schema: GraphQLSchema;
-  fetcher: Fetcher;
+  link?: ApolloLink;
+  fetcher?: Fetcher;
 }): GraphQLSchema {
+  if (fetcher && !link) {
+    link = fetcherToLink(fetcher);
+  }
+
   const queryType = schema.getQueryType();
   const queries = queryType.getFields();
   const queryResolvers: IResolverObject = {};
   Object.keys(queries).forEach(key => {
-    queryResolvers[key] = createResolver(fetcher);
+    queryResolvers[key] = createResolver(link);
   });
   let mutationResolvers: IResolverObject = {};
   const mutationType = schema.getMutationType();
   if (mutationType) {
     const mutations = mutationType.getFields();
     Object.keys(mutations).forEach(key => {
-      mutationResolvers[key] = createResolver(fetcher);
+      mutationResolvers[key] = createResolver(link);
     });
   }
 
@@ -88,18 +116,18 @@ export default function makeRemoteExecutableSchema({
   });
 }
 
-function createResolver(fetcher: Fetcher): GraphQLFieldResolver<any, any> {
+function createResolver(link: ApolloLink): GraphQLFieldResolver<any, any> {
   return async (root, args, context, info) => {
     const operation = print(info.operation);
     const fragments = Object.keys(info.fragments)
       .map(fragment => print(info.fragments[fragment]))
       .join('\n');
     const query = `${operation}\n${fragments}`;
-    const result = await fetcher({
-      query,
+    const result = await makePromise(execute(link, {
+      query: typeof query === 'string' ? parse(query) : query,
       variables: info.variableValues,
       context,
-    });
+    }));
     const fieldName = info.fieldNodes[0].alias
       ? info.fieldNodes[0].alias.value
       : info.fieldName;


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
This PR adjusts the fetcher portion of graphql-tools to accept a link or a fetcher. The idea is we would deprecate (potentially) using a fetcher in favor of a link stack since it makes it easier to do more complex actions and long term would make things like stitched `defer`, `live`, and more possible.

Docs link: https://github.com/apollographql/tools-docs/pull/135