### PR TITLE
add in linkContext creator api

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -369,16 +369,19 @@ function addMockFunctionsToSchema({
               return undefined !== resolvedValue ? resolvedValue : mockedValue;
             }
 
-        if (isObject(mockedValue) && isObject(resolvedValue)) {
-          // Object.assign() won't do here, as we need to all properties, including
-          // the non-enumerable ones and defined using Object.defineProperty
-          const emptyObject = Object.create(Object.getPrototypeOf(resolvedValue));
-          return copyOwnProps(emptyObject, resolvedValue, mockedValue);
-        }
-        return (undefined !== resolvedValue) ? resolvedValue : mockedValue;
-      });
-    }
-  });
+            if (isObject(mockedValue) && isObject(resolvedValue)) {
+              // Object.assign() won't do here, as we need to all properties, including
+              // the non-enumerable ones and defined using Object.defineProperty
+              const emptyObject = Object.create(
+                Object.getPrototypeOf(resolvedValue),
+              );
+              return copyOwnProps(emptyObject, resolvedValue, mockedValue);
+            }
+            return undefined !== resolvedValue ? resolvedValue : mockedValue;
+          });
+      }
+    },
+  );
 }
 
 class MockList {

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -7,7 +7,7 @@ const parsedIntrospectionQuery = parse(introspectionQuery);
 
 export default async function introspectSchema(
   link: ApolloLink | Fetcher,
-  linkContext?: { [key: string]: any }
+  linkContext?: { [key: string]: any },
 ): Promise<GraphQLSchema> {
   if (!(link as ApolloLink).request) {
     link = fetcherToLink(link as Fetcher);
@@ -16,7 +16,7 @@ export default async function introspectSchema(
     execute(link as ApolloLink, {
       query: parsedIntrospectionQuery,
       context: linkContext,
-    })
+    }),
   );
   if (introspectionResult.errors || !introspectionResult.data.__schema) {
     throw introspectionResult.errors;

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -7,7 +7,7 @@ const parsedIntrospectionQuery = parse(introspectionQuery);
 
 export default async function introspectSchema(
   link: ApolloLink | Fetcher,
-  context?: { [key: string]: any },
+  linkContext?: { [key: string]: any }
 ): Promise<GraphQLSchema> {
   if (!(link as ApolloLink).request) {
     link = fetcherToLink(link as Fetcher);
@@ -15,8 +15,8 @@ export default async function introspectSchema(
   const introspectionResult = await makePromise(
     execute(link as ApolloLink, {
       query: parsedIntrospectionQuery,
-      context,
-    }),
+      context: linkContext,
+    })
   );
   if (introspectionResult.errors || !introspectionResult.data.__schema) {
     throw introspectionResult.errors;

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -24,11 +24,11 @@ export type Fetcher = (
     operationName?: string;
     variables?: { [key: string]: any };
     context?: { [key: string]: any };
-  }
+  },
 ) => Promise<ExecutionResult>;
 
 export type LinkContextCreator = (
-  context: { [key: string]: any }
+  context: { [key: string]: any },
 ) => { [key: string]: any };
 
 export const fetcherToLink = (fetcher: Fetcher): ApolloLink => {
@@ -124,11 +124,11 @@ export default function makeRemoteExecutableSchema({
 
 function createResolver(
   link: ApolloLink,
-  linkContext: LinkContextCreator
+  linkContext: LinkContextCreator,
 ): GraphQLFieldResolver<any, any> {
   return async (root, args, context, info) => {
     const fragments = Object.keys(info.fragments).map(
-      fragment => info.fragments[fragment]
+      fragment => info.fragments[fragment],
     );
     const document = {
       kind: Kind.DOCUMENT,
@@ -143,7 +143,7 @@ function createResolver(
         query: document,
         variables: info.variableValues,
         context: contextForLink,
-      })
+      }),
     );
     const fieldName = info.fieldNodes[0].alias
       ? info.fieldNodes[0].alias.value

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -24,8 +24,12 @@ export type Fetcher = (
     operationName?: string;
     variables?: { [key: string]: any };
     context?: { [key: string]: any };
-  },
+  }
 ) => Promise<ExecutionResult>;
+
+export type LinkContextCreator = (
+  context: { [key: string]: any }
+) => { [key: string]: any };
 
 export const fetcherToLink = (fetcher: Fetcher): ApolloLink => {
   return new ApolloLink(operation => {
@@ -51,10 +55,12 @@ export default function makeRemoteExecutableSchema({
   schema,
   link,
   fetcher,
+  linkContext,
 }: {
   schema: GraphQLSchema;
   link?: ApolloLink;
   fetcher?: Fetcher;
+  linkContext?: LinkContextCreator;
 }): GraphQLSchema {
   if (fetcher && !link) {
     link = fetcherToLink(fetcher);
@@ -64,14 +70,14 @@ export default function makeRemoteExecutableSchema({
   const queries = queryType.getFields();
   const queryResolvers: IResolverObject = {};
   Object.keys(queries).forEach(key => {
-    queryResolvers[key] = createResolver(link);
+    queryResolvers[key] = createResolver(link, linkContext);
   });
   let mutationResolvers: IResolverObject = {};
   const mutationType = schema.getMutationType();
   if (mutationType) {
     const mutations = mutationType.getFields();
     Object.keys(mutations).forEach(key => {
-      mutationResolvers[key] = createResolver(link);
+      mutationResolvers[key] = createResolver(link, linkContext);
     });
   }
 
@@ -116,21 +122,28 @@ export default function makeRemoteExecutableSchema({
   });
 }
 
-function createResolver(link: ApolloLink): GraphQLFieldResolver<any, any> {
+function createResolver(
+  link: ApolloLink,
+  linkContext: LinkContextCreator
+): GraphQLFieldResolver<any, any> {
   return async (root, args, context, info) => {
     const fragments = Object.keys(info.fragments).map(
-      fragment => info.fragments[fragment],
+      fragment => info.fragments[fragment]
     );
     const document = {
       kind: Kind.DOCUMENT,
       definitions: [info.operation, ...fragments],
     };
+    let contextForLink = {};
+    if (linkContext && typeof linkContext === 'function') {
+      contextForLink = linkContext(context);
+    }
     const result = await makePromise(
       execute(link, {
         query: document,
         variables: info.variableValues,
-        context,
-      }),
+        context: contextForLink,
+      })
     );
     const fieldName = info.fieldNodes[0].alias
       ? info.fieldNodes[0].alias.value

--- a/src/test/testMocking.ts
+++ b/src/test/testMocking.ts
@@ -153,17 +153,21 @@ describe('Mock', () => {
       Bird: () => ({ returnInt: () => 54321 }),
       Bee: () => ({ returnInt: () => 54321 }),
     };
-    return mockServer(shorthand, mockMap).query(testQuery).then((res: any) => {
-      expect(res.data.returnInt).to.equal(12345);
-      expect(res.data.returnFloat).to.be.a('number').within(-1000, 1000);
-      expect(res.data.returnBoolean).to.be.a('boolean');
-      expect(res.data.returnString).to.be.a('string');
-      expect(res.data.returnID).to.be.a('string');
-      // tests that resolveType is correctly set for unions and interfaces
-      // and that the correct mock function is used
-      expect(res.data.returnBirdsAndBees[0].returnInt).to.equal(54321);
-      expect(res.data.returnBirdsAndBees[1].returnInt).to.equal(54321);
-    });
+    return mockServer(shorthand, mockMap)
+      .query(testQuery)
+      .then((res: any) => {
+        expect(res.data.returnInt).to.equal(12345);
+        expect(res.data.returnFloat)
+          .to.be.a('number')
+          .within(-1000, 1000);
+        expect(res.data.returnBoolean).to.be.a('boolean');
+        expect(res.data.returnString).to.be.a('string');
+        expect(res.data.returnID).to.be.a('string');
+        // tests that resolveType is correctly set for unions and interfaces
+        // and that the correct mock function is used
+        expect(res.data.returnBirdsAndBees[0].returnInt).to.equal(54321);
+        expect(res.data.returnBirdsAndBees[1].returnInt).to.equal(54321);
+      });
   });
 
   it('mockServer is able to preserveResolvers of a prebuilt schema', () => {
@@ -227,17 +231,21 @@ describe('Mock', () => {
       Bird: () => ({ returnInt: () => 54321 }),
       Bee: () => ({ returnInt: () => 54321 }),
     };
-    return mockServer(jsSchema, mockMap).query(testQuery).then((res: any) => {
-      expect(res.data.returnInt).to.equal(12345);
-      expect(res.data.returnFloat).to.be.a('number').within(-1000, 1000);
-      expect(res.data.returnBoolean).to.be.a('boolean');
-      expect(res.data.returnString).to.be.a('string');
-      expect(res.data.returnID).to.be.a('string');
-      // tests that resolveType is correctly set for unions and interfaces
-      // and that the correct mock function is used
-      expect(res.data.returnBirdsAndBees[0].returnInt).to.equal(54321);
-      expect(res.data.returnBirdsAndBees[1].returnInt).to.equal(54321);
-    });
+    return mockServer(jsSchema, mockMap)
+      .query(testQuery)
+      .then((res: any) => {
+        expect(res.data.returnInt).to.equal(12345);
+        expect(res.data.returnFloat)
+          .to.be.a('number')
+          .within(-1000, 1000);
+        expect(res.data.returnBoolean).to.be.a('boolean');
+        expect(res.data.returnString).to.be.a('string');
+        expect(res.data.returnID).to.be.a('string');
+        // tests that resolveType is correctly set for unions and interfaces
+        // and that the correct mock function is used
+        expect(res.data.returnBirdsAndBees[0].returnInt).to.equal(54321);
+        expect(res.data.returnBirdsAndBees[1].returnInt).to.equal(54321);
+      });
   });
 
   it('does not mask resolveType functions if you tell it not to', () => {
@@ -1379,7 +1387,6 @@ describe('Mock', () => {
   });
 
   it('allows instanceof checks in __resolveType', () => {
-
     class Account {
       public id: string;
       public username: string;
@@ -1413,7 +1420,7 @@ describe('Mock', () => {
       Query: {
         node: () => {
           return new Account();
-        }
+        },
       },
       Node: {
         __resolveType: (obj: any) => {
@@ -1422,8 +1429,8 @@ describe('Mock', () => {
           } else {
             return null;
           }
-        }
-      }
+        },
+      },
     };
 
     const schema = makeExecutableSchema({
@@ -1433,7 +1440,7 @@ describe('Mock', () => {
 
     addMockFunctionsToSchema({
       schema,
-      preserveResolvers: true
+      preserveResolvers: true,
     });
 
     const query = `
@@ -1451,9 +1458,9 @@ describe('Mock', () => {
       data: {
         node: {
           id: '123nmasb',
-          username: 'foo@bar.com'
-        }
-      }
+          username: 'foo@bar.com',
+        },
+      },
     };
     return graphql(schema, query).then(res => {
       expect(res).to.deep.equal(expected);

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -31,16 +31,16 @@ describe('Resolve', () => {
     const resolvers = {
       RootQuery: {
         printRoot,
-        printRootAgain: printRoot
+        printRootAgain: printRoot,
       },
       RootMutation: {
-        printRoot
+        printRoot,
       },
       RootSubscription: {
         printRoot: {
-          subscribe: () => pubsub.asyncIterator('printRootChannel')
-        }
-      }
+          subscribe: () => pubsub.asyncIterator('printRootChannel'),
+        },
+      },
     };
     const schema = makeExecutableSchema({ typeDefs, resolvers });
     let schemaLevelResolveFunctionCalls = 0;
@@ -60,11 +60,11 @@ describe('Resolve', () => {
             printRootAgain
           }
         `,
-        root
+        root,
       ).then(({ data }) => {
         assert.deepEqual(data, {
           printRoot: root,
-          printRootAgain: root
+          printRootAgain: root,
         });
         assert.equal(schemaLevelResolveFunctionCalls, 1);
       });
@@ -85,31 +85,42 @@ describe('Resolve', () => {
             subscription TestSubscription {
               printRoot
             }
-          `)
-        ).then(results => {
-          forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
-            if (result.errors) {
-              return done(new Error(`Unexpected errors in GraphQL result: ${result.errors}`));
-            }
+          `),
+        )
+          .then(results => {
+            forAwaitEach(
+              results as AsyncIterable<ExecutionResult>,
+              (result: ExecutionResult) => {
+                if (result.errors) {
+                  return done(
+                    new Error(
+                      `Unexpected errors in GraphQL result: ${result.errors}`,
+                    ),
+                  );
+                }
 
-            const subsData = result.data;
-            subsCbkCalls++;
-            try {
-              if (subsCbkCalls === 1) {
-                assert.equal(schemaLevelResolveFunctionCalls, 1);
-                assert.deepEqual(subsData, { printRoot: subscriptionRoot });
-                return resolveFirst();
-              } else if (subsCbkCalls === 2) {
-                assert.equal(schemaLevelResolveFunctionCalls, 4);
-                assert.deepEqual(subsData, { printRoot: subscriptionRoot2 });
-                return done();
-              }
-            } catch (e) {
-              return done(e);
-            }
-            done(new Error('Too many subscription fired'));
-          }).catch(done);
-        }).catch(done);
+                const subsData = result.data;
+                subsCbkCalls++;
+                try {
+                  if (subsCbkCalls === 1) {
+                    assert.equal(schemaLevelResolveFunctionCalls, 1);
+                    assert.deepEqual(subsData, { printRoot: subscriptionRoot });
+                    return resolveFirst();
+                  } else if (subsCbkCalls === 2) {
+                    assert.equal(schemaLevelResolveFunctionCalls, 4);
+                    assert.deepEqual(subsData, {
+                      printRoot: subscriptionRoot2,
+                    });
+                    return done();
+                  }
+                } catch (e) {
+                  return done(e);
+                }
+                done(new Error('Too many subscription fired'));
+              },
+            ).catch(done);
+          })
+          .catch(done);
       });
 
       pubsub.publish('printRootChannel', { printRoot: subscriptionRoot });
@@ -123,8 +134,8 @@ describe('Resolve', () => {
                 printRoot
               }
             `,
-            queryRoot
-          )
+            queryRoot,
+          ),
         )
         .then(({ data }) => {
           assert.equal(schemaLevelResolveFunctionCalls, 2);
@@ -136,7 +147,7 @@ describe('Resolve', () => {
                 printRoot
               }
             `,
-            mutationRoot
+            mutationRoot,
           );
         })
         .then(({ data: mutationData }) => {

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -10,7 +10,7 @@ import {
   IntValueNode,
   parse,
   ExecutionResult,
-  GraphQLError
+  GraphQLError,
 } from 'graphql';
 // import { printSchema } from 'graphql';
 const GraphQLJSON = require('graphql-type-json');
@@ -25,7 +25,11 @@ import {
   chainResolvers,
   concatenateTypeDefs,
 } from '../schemaGenerator';
-import { IResolverValidationOptions, IResolvers, IExecutableSchemaDefinition } from '../Interfaces';
+import {
+  IResolverValidationOptions,
+  IResolvers,
+  IExecutableSchemaDefinition,
+} from '../Interfaces';
 import 'mocha';
 
 interface Bird {
@@ -657,8 +661,8 @@ describe('generating schema from shorthand', () => {
     });
     expect(jsSchema.getQueryType().name).to.equal('Query');
     expect(jsSchema.getType('JSON')).to.be.an.instanceof(GraphQLScalarType);
-    expect(jsSchema.getType('JSON')).to.have
-      .property('description')
+    expect(jsSchema.getType('JSON'))
+      .to.have.property('description')
       .that.is.a('string');
     expect(jsSchema.getType('JSON')['description']).to.have.length.above(0);
   });
@@ -972,7 +976,10 @@ describe('generating schema from shorthand', () => {
     const rf = { Query: { bird: 'NOT A FUNCTION' } };
 
     expect(() =>
-      makeExecutableSchema({ typeDefs: short, resolvers: rf } as IExecutableSchemaDefinition),
+      makeExecutableSchema({
+        typeDefs: short,
+        resolvers: rf,
+      } as IExecutableSchemaDefinition),
     ).to.throw('Resolver Query.bird must be object or function');
   });
 
@@ -1847,12 +1854,9 @@ describe('chainResolvers', () => {
     const rChained = chainResolvers([r1, undefined, r3]);
     // faking the resolve info here.
     expect(
-      rChained(
-        0,
-        { name: 'tony' },
-        null,
-        { fieldName: 'person' } as GraphQLResolveInfo,
-      ),
+      rChained(0, { name: 'tony' }, null, {
+        fieldName: 'person',
+      } as GraphQLResolveInfo),
     ).to.equals('tony');
   });
 });

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -143,7 +143,7 @@ function values<T>(o: { [s: string]: T }): T[] {
 function coerceString(value: any): string {
   if (Array.isArray(value)) {
     throw new TypeError(
-      `String cannot represent an array value: [${String(value)}]`
+      `String cannot represent an array value: [${String(value)}]`,
     );
   }
   return String(value);
@@ -400,7 +400,7 @@ const bookingResolvers: IResolvers = {
     },
     bookingsByPropertyId(parent, { propertyId, limit }) {
       const list = values(sampleData.Booking).filter(
-        (booking: Booking) => booking.propertyId === propertyId
+        (booking: Booking) => booking.propertyId === propertyId,
       );
       if (limit) {
         return list.slice(0, limit);
@@ -432,7 +432,7 @@ const bookingResolvers: IResolvers = {
   Mutation: {
     addBooking(
       parent,
-      { input: { propertyId, customerId, startTime, endTime } }
+      { input: { propertyId, customerId, startTime, endTime } },
     ) {
       return {
         id: 'newId',
@@ -453,7 +453,7 @@ const bookingResolvers: IResolvers = {
   Customer: {
     bookings(parent: Customer) {
       return values(sampleData.Booking).filter(
-        (booking: Booking) => booking.customerId === parent.id
+        (booking: Booking) => booking.customerId === parent.id,
       );
     },
     vehicle(parent: Customer) {
@@ -525,5 +525,5 @@ async function makeExecutableSchemaFromFetcher(schema: GraphQLSchema) {
 
 export const remotePropertySchema = makeSchemaRemoteFromLink(propertySchema);
 export const remoteBookingSchema = makeExecutableSchemaFromFetcher(
-  bookingSchema
+  bookingSchema,
 );

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -143,7 +143,7 @@ function values<T>(o: { [s: string]: T }): T[] {
 function coerceString(value: any): string {
   if (Array.isArray(value)) {
     throw new TypeError(
-      `String cannot represent an array value: [${String(value)}]`,
+      `String cannot represent an array value: [${String(value)}]`
     );
   }
   return String(value);
@@ -400,7 +400,7 @@ const bookingResolvers: IResolvers = {
     },
     bookingsByPropertyId(parent, { propertyId, limit }) {
       const list = values(sampleData.Booking).filter(
-        (booking: Booking) => booking.propertyId === propertyId,
+        (booking: Booking) => booking.propertyId === propertyId
       );
       if (limit) {
         return list.slice(0, limit);
@@ -432,7 +432,7 @@ const bookingResolvers: IResolvers = {
   Mutation: {
     addBooking(
       parent,
-      { input: { propertyId, customerId, startTime, endTime } },
+      { input: { propertyId, customerId, startTime, endTime } }
     ) {
       return {
         id: 'newId',
@@ -453,7 +453,7 @@ const bookingResolvers: IResolvers = {
   Customer: {
     bookings(parent: Customer) {
       return values(sampleData.Booking).filter(
-        (booking: Booking) => booking.customerId === parent.id,
+        (booking: Booking) => booking.customerId === parent.id
       );
     },
     vehicle(parent: Customer) {
@@ -488,12 +488,12 @@ export const bookingSchema: GraphQLSchema = makeExecutableSchema({
 
 // Pretend this schema is remote
 async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
-  const link = new ApolloLink((operation) => {
+  const link = new ApolloLink(operation => {
     return new Observable(observer => {
       const { query, operationName, variables } = operation;
       const context = operation.getContext();
       graphql(schema, print(query), null, context, variables, operationName)
-        .then((result) => {
+        .then(result => {
           observer.next(result);
           observer.complete();
         })
@@ -502,7 +502,11 @@ async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
   });
 
   const clientSchema = await introspectSchema(link);
-  return makeRemoteExecutableSchema({ schema: clientSchema, link });
+  return makeRemoteExecutableSchema({
+    schema: clientSchema,
+    link,
+    linkContext: context => context,
+  });
 }
 
 // ensure fetcher support exists from the 2.0 api
@@ -512,8 +516,14 @@ async function makeExecutableSchemaFromFetcher(schema: GraphQLSchema) {
   };
 
   const clientSchema = await introspectSchema(fetcher);
-  return makeRemoteExecutableSchema({ schema: clientSchema, fetcher });
+  return makeRemoteExecutableSchema({
+    schema: clientSchema,
+    fetcher,
+    linkContext: context => context,
+  });
 }
 
 export const remotePropertySchema = makeSchemaRemoteFromLink(propertySchema);
-export const remoteBookingSchema = makeExecutableSchemaFromFetcher(bookingSchema);
+export const remoteBookingSchema = makeExecutableSchemaFromFetcher(
+  bookingSchema
+);

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -143,7 +143,7 @@ function values<T>(o: { [s: string]: T }): T[] {
 function coerceString(value: any): string {
   if (Array.isArray(value)) {
     throw new TypeError(
-      `String cannot represent an array value: [${String(value)}]`,
+      `String cannot represent an array value: [${String(value)}]`
     );
   }
   return String(value);
@@ -400,7 +400,7 @@ const bookingResolvers: IResolvers = {
     },
     bookingsByPropertyId(parent, { propertyId, limit }) {
       const list = values(sampleData.Booking).filter(
-        (booking: Booking) => booking.propertyId === propertyId,
+        (booking: Booking) => booking.propertyId === propertyId
       );
       if (limit) {
         return list.slice(0, limit);
@@ -432,7 +432,7 @@ const bookingResolvers: IResolvers = {
   Mutation: {
     addBooking(
       parent,
-      { input: { propertyId, customerId, startTime, endTime } },
+      { input: { propertyId, customerId, startTime, endTime } }
     ) {
       return {
         id: 'newId',
@@ -453,7 +453,7 @@ const bookingResolvers: IResolvers = {
   Customer: {
     bookings(parent: Customer) {
       return values(sampleData.Booking).filter(
-        (booking: Booking) => booking.customerId === parent.id,
+        (booking: Booking) => booking.customerId === parent.id
       );
     },
     vehicle(parent: Customer) {
@@ -491,8 +491,15 @@ async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
   const link = new ApolloLink(operation => {
     return new Observable(observer => {
       const { query, operationName, variables } = operation;
-      const context = operation.getContext();
-      graphql(schema, print(query), null, context, variables, operationName)
+      const { graphqlContext } = operation.getContext();
+      graphql(
+        schema,
+        print(query),
+        null,
+        graphqlContext,
+        variables,
+        operationName
+      )
         .then(result => {
           observer.next(result);
           observer.complete();
@@ -505,7 +512,6 @@ async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
   return makeRemoteExecutableSchema({
     schema: clientSchema,
     link,
-    linkContext: context => context,
   });
 }
 
@@ -519,11 +525,10 @@ async function makeExecutableSchemaFromFetcher(schema: GraphQLSchema) {
   return makeRemoteExecutableSchema({
     schema: clientSchema,
     fetcher,
-    linkContext: context => context,
   });
 }
 
 export const remotePropertySchema = makeSchemaRemoteFromLink(propertySchema);
 export const remoteBookingSchema = makeExecutableSchemaFromFetcher(
-  bookingSchema,
+  bookingSchema
 );


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Due to the fact that context differs between how apollo-links work and how context is used within graphql resolvers. This introduces a new API called `LinkContextCreator` which takes the context from the resolver and returns a context object for the apollo-links.