### PR TITLE
Handle aliases in all fields in merged and remote schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### VNEXT
+
+* Fix alias issues [Issue #415](https://github.com/apollographql/graphql-tools/issues/415) [PR #418](https://github.com/apollographql/graphql-tools/pull/418)
+
 ### 2.2.1
 
 * Fix inability to add recursive queries [PR #413](https://github.com/apollographql/graphql-tools/pull/413)

--- a/src/stitching/aliasAwareResolver.ts
+++ b/src/stitching/aliasAwareResolver.ts
@@ -1,0 +1,19 @@
+import { GraphQLFieldResolver } from 'graphql';
+
+const aliasAwareResolver: GraphQLFieldResolver<any, any> = (
+  parent,
+  args,
+  context,
+  info,
+) => {
+  const fieldName = info.fieldNodes[0].alias
+    ? info.fieldNodes[0].alias.value
+    : info.fieldName;
+  if (parent) {
+    return parent[fieldName];
+  } else {
+    return null;
+  }
+};
+
+export default aliasAwareResolver;

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -53,6 +53,7 @@ import {
   addResolveFunctionsToSchema,
 } from '../schemaGenerator';
 import resolveFromParentTypename from './resolveFromParentTypename';
+import aliasAwareResolver from './aliasAwareResolver';
 
 export type MergeInfo = {
   delegate: (
@@ -289,6 +290,7 @@ function fieldToFieldConfig(
   return {
     type: registry.resolveType(field.type),
     args: argsToFieldConfigArgumentMap(field.args, registry),
+    resolve: aliasAwareResolver,
     description: field.description,
     deprecationReason: field.deprecationReason,
   };
@@ -727,13 +729,6 @@ function filterSelectionSet(
           } else {
             typeStack.push(field.type);
           }
-        }
-
-        if (node.alias) {
-          return {
-            ...node,
-            alias: null,
-          };
         }
       },
       leave() {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -913,28 +913,7 @@ bookingById(id: $b1) {
       });
     });
 
-    describe('regression', () => {
-      it('should not pass extra arguments to delegates', async () => {
-        const result = await graphql(
-          mergedSchema,
-          `
-            query {
-              delegateArgumentTest(arbitraryArg: 5) {
-                id
-              }
-            }
-          `,
-        );
-
-        expect(result).to.deep.equal({
-          data: {
-            delegateArgumentTest: {
-              id: 'p1',
-            },
-          },
-        });
-      });
-
+    describe('aliases', () => {
       it('aliases', async () => {
         const result = await graphql(
           mergedSchema,
@@ -1001,6 +980,84 @@ bookingById(id: $b1) {
                   },
                 },
               ],
+            },
+          },
+        });
+      });
+
+      it('aliases subschema queries', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              customerById(id: "c1") {
+                id
+                firstBooking: bookings(limit: 1) {
+                  id
+                  property {
+                    id
+                  }
+                }
+                allBookings: bookings(limit: 10) {
+                  id
+                  property {
+                    id
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            customerById: {
+              id: 'c1',
+              firstBooking: [
+                {
+                  id: 'b1',
+                  property: {
+                    id: 'p1',
+                  },
+                },
+              ],
+              allBookings: [
+                {
+                  id: 'b1',
+                  property: {
+                    id: 'p1',
+                  },
+                },
+                {
+                  id: 'b4',
+                  property: {
+                    id: 'p2',
+                  },
+                },
+              ],
+            },
+          },
+        });
+      });
+    });
+
+    describe('regression', () => {
+      it('should not pass extra arguments to delegates', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              delegateArgumentTest(arbitraryArg: 5) {
+                id
+              }
+            }
+          `,
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            delegateArgumentTest: {
+              id: 'p1',
             },
           },
         });

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -452,10 +452,15 @@ const bookingResolvers: IResolvers = {
   },
 
   Customer: {
-    bookings(parent: Customer) {
-      return values(sampleData.Booking).filter(
+    bookings(parent: Customer, { limit }) {
+      const list = values(sampleData.Booking).filter(
         (booking: Booking) => booking.customerId === parent.id,
       );
+      if (limit) {
+        return list.slice(0, limit);
+      } else {
+        return list;
+      }
     },
     vehicle(parent: Customer) {
       return sampleData.Vehicle[parent.vehicleId];


### PR DESCRIPTION
Pass through queries with aliases, but make fields be aware of their
aliases.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
