### PR TITLE
Do not throw on empty errors array in introspectSchema

### DIFF
--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -18,7 +18,10 @@ export default async function introspectSchema(
     context: linkContext,
   });
 
-  if (introspectionResult.errors || !introspectionResult.data.__schema) {
+  if (
+    (introspectionResult.errors && introspectionResult.errors.length) ||
+    !introspectionResult.data.__schema
+  ) {
     throw introspectionResult.errors;
   } else {
     const schema = buildClientSchema(introspectionResult.data as {


### PR DESCRIPTION
https://github.com/apollographql/graphql-tools/issues/455

---

Do not throw when `introspectSchema` receives a response with an empty `errors` array.