### PR TITLE
`resolvers` parameter should be optional for `mergeSchemas`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### VNEXT
 
-* ...
+* Made `resolvers` parameter optional for `mergeSchemas` [Issue #461](https://github.com/apollographql/graphql-tools/issues/461) [PR #462] (https://github.com/apollographql/graphql-tools/pull/462)
 
 ### v2.7.0
 

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -76,7 +76,7 @@ export default function mergeSchemas({
     leftType: GraphQLNamedType,
     rightType: GraphQLNamedType,
   ) => GraphQLNamedType;
-  resolvers: (mergeInfo: MergeInfo) => IResolvers;
+  resolvers?: (mergeInfo: MergeInfo) => IResolvers;
 }): GraphQLSchema {
   if (!onTypeConflict) {
     onTypeConflict = defaultOnTypeConflict;


### PR DESCRIPTION
Per the documentation and runtime behavior. See #461 

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
