### PR TITLE
Basic subscriptions support added to mergeSchemas and TypeRegistry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * Add the option `resolverValidationOptions.allowResolversNotInSchema` to allow resolvers to be set even when they are not defined in the schemas [PR #444](https://github.com/apollographql/graphql-tools/pull/444)
 * Fix schema stitching bug when aliases are used with union types and fragments [PR #482](https://github.com/apollographql/graphql-tools/pull/482)
+* Added basic subscription support for local schemas [Issue #420](https://github.com/apollographql/graphql-tools/issues/420) [PR #463] (https://github.com/apollographql/graphql-tools/pull/463)
 
 ### v2.7.2
 
 * Incompatible fragments are now properly filtered [PR #470](https://github.com/apollographql/graphql-tools/pull/470)
-* Added basic subscription support for local schemas [Issue #420](https://github.com/apollographql/graphql-tools/issues/420) [PR #463] (https://github.com/apollographql/graphql-tools/pull/463)
 
 ### v2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### VNEXT
 
 * Made `resolvers` parameter optional for `mergeSchemas` [Issue #461](https://github.com/apollographql/graphql-tools/issues/461) [PR #462] (https://github.com/apollographql/graphql-tools/pull/462)
+* Added basic subscription support for local schemas [Issue #420](https://github.com/apollographql/graphql-tools/issues/420) [PR #463] (https://github.com/apollographql/graphql-tools/pull/463)
 
 ### v2.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ### VNEXT
 
 * Incompatible fragments are now properly filtered [PR #470](https://github.com/apollographql/graphql-tools/pull/470)
+* Added basic subscription support for local schemas [Issue #420](https://github.com/apollographql/graphql-tools/issues/420) [PR #463] (https://github.com/apollographql/graphql-tools/pull/463)
 
 ### v2.7.1
 
 * Made `resolvers` parameter optional for `mergeSchemas` [Issue #461](https://github.com/apollographql/graphql-tools/issues/461) [PR #462] (https://github.com/apollographql/graphql-tools/pull/462)
-* Added basic subscription support for local schemas [Issue #420](https://github.com/apollographql/graphql-tools/issues/420) [PR #463] (https://github.com/apollographql/graphql-tools/pull/463)
 * Make it possible to define interfaces in schema extensions [PR # 464](https://github.com/apollographql/graphql-tools/pull/464)
 
 ### v2.7.0

--- a/src/stitching/TypeRegistry.ts
+++ b/src/stitching/TypeRegistry.ts
@@ -19,6 +19,7 @@ export default class TypeRegistry {
   private schemaByField: {
     query: { [key: string]: GraphQLSchema };
     mutation: { [key: string]: GraphQLSchema };
+    subscription: { [key: string]: GraphQLSchema };
   };
 
   constructor() {
@@ -26,12 +27,13 @@ export default class TypeRegistry {
     this.schemaByField = {
       query: {},
       mutation: {},
+      subscription: {}
     };
     this.fragmentReplacements = {};
   }
 
   public getSchemaByField(
-    operation: 'query' | 'mutation',
+    operation: 'query' | 'mutation' | 'subscription',
     fieldName: string,
   ): GraphQLSchema {
     return this.schemaByField[operation][fieldName];
@@ -74,6 +76,14 @@ export default class TypeRegistry {
       const fieldNames = Object.keys(mutation.getFields());
       fieldNames.forEach(field => {
         this.schemaByField.mutation[field] = schema;
+      });
+    }
+
+    const subscription = schema.getSubscriptionType();
+    if (subscription) {
+      const fieldNames = Object.keys(subscription.getFields());
+      fieldNames.forEach(field => {
+        this.schemaByField.subscription[field] = schema;
       });
     }
   }

--- a/src/stitching/defaultMergedResolver.ts
+++ b/src/stitching/defaultMergedResolver.ts
@@ -23,6 +23,12 @@ const defaultMergedResolver: GraphQLFieldResolver<any, any> = (
     );
   } else if (parent) {
     let result = parent[responseKey];
+
+    // subscription result mapping
+    if (!result && parent.data && parent.data[responseKey]) {
+      result = parent.data[responseKey];
+    }
+
     if (errorResult.errors) {
       result = annotateWithChildrenErrors(result, errorResult.errors);
     }

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -13,6 +13,7 @@ import makeRemoteExecutableSchema, {
   Fetcher,
 } from '../stitching/makeRemoteExecutableSchema';
 import introspectSchema from '../stitching/introspectSchema';
+import {PubSub} from 'graphql-subscriptions';
 
 export type Property = {
   id: string;
@@ -502,6 +503,34 @@ const bookingResolvers: IResolvers = {
   DateTime,
 };
 
+const subscriptionTypeDefs = `
+  type Notification{
+    text: String
+  }
+
+  type Query{
+    notifications: Notification
+  }
+
+  type Subscription{
+    notifications: Notification
+  }
+`;
+
+export const subscriptionPubSub = new PubSub();
+export const subscriptionPubSubTrigger = 'pubSubTrigger';
+
+const subscriptionResolvers: IResolvers = {
+  Query: {
+    notifications: (root: any) => ({ text: 'Hello world'})
+  },
+  Subscription: {
+    notifications: {
+      subscribe: () => subscriptionPubSub.asyncIterator(subscriptionPubSubTrigger),
+    },
+  }
+};
+
 export const propertySchema: GraphQLSchema = makeExecutableSchema({
   typeDefs: propertyAddressTypeDefs,
   resolvers: propertyResolvers,
@@ -510,6 +539,11 @@ export const propertySchema: GraphQLSchema = makeExecutableSchema({
 export const bookingSchema: GraphQLSchema = makeExecutableSchema({
   typeDefs: bookingAddressTypeDefs,
   resolvers: bookingResolvers,
+});
+
+export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
+  typeDefs: subscriptionTypeDefs,
+  resolvers: subscriptionResolvers,
 });
 
 // Pretend this schema is remote


### PR DESCRIPTION
#420 - FourTwenty :)
Added support for subscription type (subscriptions will work with local schema only).

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
