### PR TITLE
Fix alias of union types

### DIFF
--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -595,6 +595,10 @@ function filterSelectionSet(
           } else {
             typeStack.push(field.type);
           }
+        } else if (
+          parentType instanceof GraphQLUnionType && node.name.value === '__typename'
+        ) {
+          typeStack.push(TypeNameMetaFieldDef.type);
         }
       },
       leave() {

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -610,8 +610,9 @@ function filterSelectionSet(
       const parentTypeName = parentType.name;
       let selections = node.selections;
       if (
-        parentType instanceof GraphQLInterfaceType ||
-        parentType instanceof GraphQLUnionType
+        (parentType instanceof GraphQLInterfaceType ||
+        parentType instanceof GraphQLUnionType) &&
+        (!selections.find(_ => (_ as FieldNode).kind === Kind.FIELD && (_ as FieldNode).name.value === '__typename') )
       ) {
         selections = selections.concat({
           kind: Kind.FIELD,

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -578,6 +578,41 @@ bookingById(id: "b1") {
         });
       });
 
+      it('unions with alias', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              customerById(id: "c1") {
+                ... on Person {
+                  name
+                }
+                v1: vehicle {
+                  ... on Bike {
+                    bikeType
+                  }
+                }
+                v2: vehicle {
+                  ... on Bike {
+                    bikeType
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            customerById: {
+              name: 'Exampler Customer',
+              v1: { bikeType: 'MOUNTAIN' },
+              v2: { bikeType: 'MOUNTAIN' },
+            },
+          },
+        });
+      });
+
       it('deep links', async () => {
         const mergedResult = await graphql(
           mergedSchema,


### PR DESCRIPTION
I was having some issues using union types. I create a test to simulate my conditions.

```javascript
      it('unions with alias', async () => {
        const mergedResult = await graphql(
          mergedSchema,
          `
            query {
              customerById(id: "c1") {
                ... on Person {
                  name
                }
                v1: vehicle {
                  ... on Bike {
                    bikeType
                  }
                }
                v2: vehicle {
                  ... on Bike {
                    bikeType
                  }
                }
              }
            }
          `,
        );

        expect(mergedResult).to.deep.equal({
          data: {
            customerById: {
              name: 'Exampler Customer',
              v1: { bikeType: 'MOUNTAIN' },
              v2: { bikeType: 'MOUNTAIN' },
            },
          },
        });
      });
```
This test doesn't pass but is a valid query.

I looked at the code and I found in **/src/stitching/mergeSchemas.ts** that the method `filterSelectionSet`  is doing this when it find a set of fields of a type:

L612
```javascript
 if (
        parentType instanceof GraphQLInterfaceType ||
        parentType instanceof GraphQLUnionType
      ) {
        selections = selections.concat({
          kind: Kind.FIELD,
          name: {
            kind: Kind.NAME,
            value: '__typename',
          },
        });
      }
```
So, is adding '__typename' field to the list of field requested in case of a union type or an interface. But when resolve each of field:

L584
```javascript
if (
          parentType instanceof GraphQLObjectType ||
          parentType instanceof GraphQLInterfaceType
        ) {
          const fields = parentType.getFields();
          const field =
            node.name.value === '__typename'
              ? TypeNameMetaFieldDef
              : fields[node.name.value];
          if (!field) {
            return null;
          } else {
            typeStack.push(field.type);
          }
        }
```
Is not considering the case of a union type. I fix this situation by adding the case of the union.

I think this PR could fix https://github.com/apollographql/graphql-tools/issues/474.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
