### PR TITLE
[mergeSchemas] Remove `isTypeOf` from proxied schemas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * Add the option `resolverValidationOptions.allowResolversNotInSchema` to allow resolvers to be set even when they are not defined in the schemas [PR #444](https://github.com/apollographql/graphql-tools/pull/444)
 * Fix schema stitching bug when aliases are used with union types and fragments [PR #482](https://github.com/apollographql/graphql-tools/pull/482)
+* Remove `isTypeOf` guards from merged schemas [PR #484](https://github.com/apollographql/graphql-tools/pull/484)
 
 ### v2.7.2
 
 * Incompatible fragments are now properly filtered [PR #470](https://github.com/apollographql/graphql-tools/pull/470)
-* Remove `isTypeOf` guards from merged schemas [PR #484](https://github.com/apollographql/graphql-tools/pull/484)
 
 ### v2.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### VNEXT
 
 * Incompatible fragments are now properly filtered [PR #470](https://github.com/apollographql/graphql-tools/pull/470)
+* Remove `isTypeOf` guards from merged schemas [PR #484](https://github.com/apollographql/graphql-tools/pull/484)
 
 ### v2.7.1
 

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -131,6 +131,9 @@ export default function mergeSchemas({
         } else {
           newType = getNamedType(type);
         }
+        if (newType instanceof GraphQLObjectType) {
+          delete newType.isTypeOf;
+        }
         typeRegistry.addType(newType.name, newType, onTypeConflict);
       }
     });

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -659,6 +659,11 @@ bookingById(id: "b1") {
           },
         });
       });
+
+      it('removes `isTypeOf` checks from proxied schemas', () => {
+        const Booking = mergedSchema.getType('Booking') as GraphQLObjectType;
+        expect(Booking.isTypeOf).to.equal(undefined);
+      });
     });
 
     describe('fragments', () => {

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -457,6 +457,9 @@ const bookingResolvers: IResolvers = {
   },
 
   Booking: {
+    __isTypeOf(source, context, info) {
+      return Object.prototype.hasOwnProperty.call(source, 'id');
+    },
     customer(parent: Booking) {
       return sampleData.Customer[parent.customerId];
     },


### PR DESCRIPTION
These make sense in local schemas, as they have access to a complete raw
data object, however the proxied schema only gets the data that was
requested in the client’s GraphQL query which may well not include the
properties that the guard checks for.

cc @freiksenet 

----

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
