### PR TITLE
Maintain original errors through stitching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ### VNEXT
 
-* ...
+...
+
+### v2.8.1
+
+* When concatenating errors maintain a reference to the original for use downstream [Issue #480](https://github.com/apollographql/graphql-tools/issues/480) [PR #485](https://github.com/apollographql/graphql-tools/pull/485)
 
 ### v2.8.0
 

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -66,6 +66,14 @@ export function getErrorsFromParent(
   };
 }
 
+class CombinedError extends Error {
+  public errors: Error[];
+  constructor(message: string, errors: Error[]) {
+    super(message);
+    this.errors = errors;
+  }
+}
+
 export function checkResultAndHandleErrors(
   result: any,
   info: GraphQLResolveInfo,
@@ -80,8 +88,10 @@ export function checkResultAndHandleErrors(
     const errorMessage = result.errors
       .map((error: { message: string }) => error.message)
       .join('\n');
+    const combinedError = new CombinedError(errorMessage, result.errors);
+
     throw locatedError(
-      errorMessage,
+      combinedError,
       info.fieldNodes,
       responsePathAsArray(info.path),
     );


### PR DESCRIPTION
We ran into the problem raised in Issue #480 whereby original errors are swallowed up when using merged schemas. 

I propose simply attaching the original errors to the error object so they can be accessed downstream. 

I've jumped the gun here as we really need the original error on our project, so will watch discussion on #480 and look to update when necessary

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
