### PR TITLE
Bring attachDirectiveResolvers to graphql-tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### VNEXT
 
-* Added support for custom Directives [Issue #212](https://github.com/apollographql/graphql-tools/issues/212) [PR #518](https://github.com/apollographql/graphql-tools/pull/518)
+* Added support for custom Directives on FIELD [Issue #212](https://github.com/apollographql/graphql-tools/issues/212) [PR #518](https://github.com/apollographql/graphql-tools/pull/518)
 
 ### v2.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### VNEXT
 
-* ...
+* Added support for custom Directives [Issue #212](https://github.com/apollographql/graphql-tools/issues/212) [PR #518](https://github.com/apollographql/graphql-tools/pull/518)
 
 ### v2.11.0
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 
 This package provides a few useful ways to create a GraphQL schema:
 
-1. Use the GraphQL schema language to [generate a schema](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html) with full support for resolvers, interfaces, unions, and custom scalars. The schema produced is completely compatible with [GraphQL.js](https://github.com/graphql/graphql-js).
-2. [Mock your GraphQL API](http://dev.apollodata.com/tools/graphql-tools/mocking.html) with fine-grained per-type mocking
-3. Automatically [stitch multiple schemas together](http://dev.apollodata.com/tools/graphql-tools/schema-stitching.html) into one larger API
+1. Use the GraphQL schema language to [generate a schema](https://www.apollographql.com/docs/graphql-tools/generate-schema.html) with full support for resolvers, interfaces, unions, and custom scalars. The schema produced is completely compatible with [GraphQL.js](https://github.com/graphql/graphql-js).
+2. [Mock your GraphQL API](https://www.apollographql.com/docs/graphql-tools/mocking.html) with fine-grained per-type mocking
+3. Automatically [stitch multiple schemas together](https://www.apollographql.com/docs/graphql-tools/schema-stitching.html) into one larger API
 
 ## Documentation
 
-[Read the docs.](http://dev.apollodata.com/tools/graphql-tools/index.html)
+[Read the docs.](https://www.apollographql.com/docs/graphql-tools/)
 
 ## Example
 
@@ -106,7 +106,7 @@ const executableSchema = makeExecutableSchema({
 });
 ```
 
-This example has the entire type definition in one string and all resolvers in one file, but you can combine types and resolvers from multiple files and objects, as documented in the [modularizing the schema](http://dev.apollodata.com/tools/graphql-tools/generate-schema.html#modularizing) section of the docs.
+This example has the entire type definition in one string and all resolvers in one file, but you can combine types and resolvers from multiple files and objects, as documented in the [modularizing the schema](https://www.apollographql.com/docs/graphql-tools/generate-schema.html#modularizing) section of the docs.
 
 ## Contributions
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -85,9 +85,9 @@ export type IFieldIteratorFn = (
   fieldName: string,
 ) => void;
 
-export type NextResolver = () => Promise<any>;
+export type NextResolverFn = () => Promise<any>;
 export type DirectiveResolver<TSource, TContext> = (
-  next: NextResolver,
+  next: NextResolverFn,
   source: TSource,
   args: { [argName: string]: any },
   context: TContext,

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -92,7 +92,7 @@ export type DirectiveResolver<TSource, TContext> = (
   args: { [argName: string]: any },
   context: TContext,
   info: GraphQLResolveInfo,
-) => GraphQLFieldResolver<any, any>;
+) => any;
 
 export interface IDirectiveResolvers<TSource, TContext> {
   [directiveName: string]: DirectiveResolver<TSource, TContext>;

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -86,7 +86,7 @@ export type IFieldIteratorFn = (
 ) => void;
 
 export type NextResolverFn = () => Promise<any>;
-export type DirectiveResolver<TSource, TContext> = (
+export type DirectiveResolverFn<TSource, TContext> = (
   next: NextResolverFn,
   source: TSource,
   args: { [argName: string]: any },
@@ -95,7 +95,7 @@ export type DirectiveResolver<TSource, TContext> = (
 ) => any;
 
 export interface IDirectiveResolvers<TSource, TContext> {
-  [directiveName: string]: DirectiveResolver<TSource, TContext>;
+  [directiveName: string]: DirectiveResolverFn<TSource, TContext>;
 }
 
 /* XXX on mocks, args are optional, Not sure if a bug. */

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -76,7 +76,7 @@ export interface IExecutableSchemaDefinition {
   logger?: ILogger;
   allowUndefinedInResolve?: boolean;
   resolverValidationOptions?: IResolverValidationOptions;
-  directiveResolvers: IDirectiveResolvers<any, any>;
+  directiveResolvers?: IDirectiveResolvers<any, any>;
 }
 
 export type IFieldIteratorFn = (

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -76,6 +76,7 @@ export interface IExecutableSchemaDefinition {
   logger?: ILogger;
   allowUndefinedInResolve?: boolean;
   resolverValidationOptions?: IResolverValidationOptions;
+  directiveResolvers: IDirectiveResolvers<any, any>;
 }
 
 export type IFieldIteratorFn = (
@@ -83,6 +84,19 @@ export type IFieldIteratorFn = (
   typeName: string,
   fieldName: string,
 ) => void;
+
+export type NextResolver = () => Promise<any>;
+export type DirectiveResolver<TSource, TContext> = (
+  next: NextResolver,
+  source: TSource,
+  args: { [argName: string]: any },
+  context: TContext,
+  info: GraphQLResolveInfo,
+) => GraphQLFieldResolver<any, any>;
+
+export interface IDirectiveResolvers<TSource, TContext> {
+  [directiveName: string]: DirectiveResolver<TSource, TContext>;
+}
 
 /* XXX on mocks, args are optional, Not sure if a bug. */
 export type IMockFn = GraphQLFieldResolver<any, any>;

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -666,6 +666,9 @@ function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: Grap
       if (resolver) {
         const originalResolver = field.resolve || defaultFieldResolver;
         const Directive = schema.getDirective(directiveName);
+        if (typeof(Directive) === 'undefined') {
+          throw new Error(`Directive @${directiveName} is undefined. Please define in schema before using`);
+        }
         const directiveArgs = getArgumentValues(Directive, directive);
 
         field.resolve = (...args: any[]) => {

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -668,7 +668,7 @@ function attachDirectiveResolvers(
       if (resolver) {
         const originalResolver = field.resolve || defaultFieldResolver;
         const Directive = schema.getDirective(directiveName);
-        if (typeof(Directive) === 'undefined') {
+        if (typeof Directive === 'undefined') {
           throw new Error(`Directive @${directiveName} is undefined. ` +
             'Please define in schema before using');
         }

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -100,7 +100,7 @@ function _generateSchema(
   }
 
   if (directiveResolvers) {
-    attachDirectiveResolvers(directiveResolvers, schema);
+    attachDirectiveResolvers(schema, directiveResolvers);
   }
 
   return schema;
@@ -647,12 +647,15 @@ function runAtMostOncePerRequest(
   };
 }
 
-function attachDirectiveResolvers(resolvers: IDirectiveResolvers<any, any>, schema: GraphQLSchema) {
+function attachDirectiveResolvers(
+  schema: GraphQLSchema,
+  directiveResolvers: IDirectiveResolvers<any, any>,
+) {
   forEachField(schema, (field: GraphQLField<any, any>) => {
     const directives = field.astNode.directives;
     directives.forEach((directive: DirectiveNode) => {
       const directiveName = directive.name.value;
-      const resolver = resolvers[directiveName];
+      const resolver = directiveResolvers[directiveName];
 
       if (resolver) {
         const originalResolver = field.resolve || defaultFieldResolver;

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -669,7 +669,7 @@ function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: Grap
         const directiveArgs = getArgumentValues(Directive, directive);
 
         field.resolve = (...args: any[]) => {
-          const [source,, context, info] = args;
+          const [source, , context, info] = args;
           return resolver(() => {
             const promise = originalResolver.call(field, ...args);
             if (promise instanceof Promise) {
@@ -681,7 +681,7 @@ function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: Grap
       }
     });
   });
-};
+}
 
 export {
   makeExecutableSchema,

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -652,7 +652,12 @@ function attachDirectiveResolvers(
   directiveResolvers: IDirectiveResolvers<any, any>,
 ) {
   if (typeof directiveResolvers !== 'object') {
-    throw new Error('Must provide directiveResolvers as an object');
+    throw new Error(
+      `Expected directiveResolvers to be of type object, got ${typeof directiveResolvers}`,
+    );
+  }
+  if (Array.isArray(directiveResolvers)) {
+    throw new Error('Expected directiveResolvers to be of type object, got Array');
   }
   forEachField(schema, (field: GraphQLField<any, any>) => {
     const directives = field.astNode.directives;

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -647,15 +647,6 @@ function runAtMostOncePerRequest(
   };
 }
 
-/**
- * Attach directive resolvers to Schema
- * https://github.com/apollographql/graphql-tools/issues/212#issuecomment-324447078
- *
- * @author Agon Bina <agon_bina@hotmail.com>
- * @author Giau. Tran Minh <giau.tmg@gmail.com>
- * @param resolvers: resolvers of directive
- * @param schema: GraphQL schema to attach directive resolvers
- */
 function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: GraphQLSchema) {
   forEachField(schema, (field: GraphQLField<any, any>) => {
     const directives = field.astNode.directives;

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -651,6 +651,9 @@ function attachDirectiveResolvers(
   schema: GraphQLSchema,
   directiveResolvers: IDirectiveResolvers<any, any>,
 ) {
+  if (typeof directiveResolvers !== 'object') {
+    throw new Error('Must provide directiveResolvers as an object');
+  }
   forEachField(schema, (field: GraphQLField<any, any>) => {
     const directives = field.astNode.directives;
     directives.forEach((directive: DirectiveNode) => {
@@ -661,7 +664,8 @@ function attachDirectiveResolvers(
         const originalResolver = field.resolve || defaultFieldResolver;
         const Directive = schema.getDirective(directiveName);
         if (typeof(Directive) === 'undefined') {
-          throw new Error(`Directive @${directiveName} is undefined. Please define in schema before using`);
+          throw new Error(`Directive @${directiveName} is undefined. ` +
+            'Please define in schema before using');
         }
         const directiveArgs = getArgumentValues(Directive, directive);
 

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -100,7 +100,7 @@ function _generateSchema(
   }
 
   if (directiveResolvers) {
-    attachDirectives(directiveResolvers, schema);
+    attachDirectiveResolvers(directiveResolvers, schema);
   }
 
   return schema;
@@ -647,7 +647,7 @@ function runAtMostOncePerRequest(
   };
 }
 
-function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: GraphQLSchema) {
+function attachDirectiveResolvers(resolvers: IDirectiveResolvers<any, any>, schema: GraphQLSchema) {
   forEachField(schema, (field: GraphQLField<any, any>) => {
     const directives = field.astNode.directives;
     directives.forEach((directive: DirectiveNode) => {
@@ -694,5 +694,5 @@ export {
   addSchemaLevelResolveFunction,
   attachConnectorsToContext,
   concatenateTypeDefs,
-  attachDirectives,
+  attachDirectiveResolvers,
 };

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -671,11 +671,15 @@ function attachDirectives(resolvers: IDirectiveResolvers<any, any>, schema: Grap
         field.resolve = (...args: any[]) => {
           const [source, , context, info] = args;
           return resolver(() => {
-            const promise = originalResolver.call(field, ...args);
-            if (promise instanceof Promise) {
-              return promise;
+            try {
+              const promise = originalResolver.call(field, ...args);
+              if (promise instanceof Promise) {
+                return promise;
+              }
+              return Promise.resolve(promise);
+            } catch (error) {
+              return Promise.reject(error);
             }
-            return Promise.resolve(promise);
           }, source, directiveArgs, context, info);
         };
       }

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -23,6 +23,7 @@ import {
   addErrorLoggingToSchema,
   addSchemaLevelResolveFunction,
   attachConnectorsToContext,
+  attachDirectiveResolvers,
   chainResolvers,
   concatenateTypeDefs,
 } from '../schemaGenerator';
@@ -2086,6 +2087,26 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
   };
+
+  it('throws error if directiveResolvers argument is an array', () => {
+    const jsSchema = makeExecutableSchema({
+      typeDefs: testSchema,
+      resolvers: testResolvers,
+    });
+    expect(() => (<any>attachDirectiveResolvers)(jsSchema, [1])).to.throw(
+      'Expected directiveResolvers to be of type object, got Array',
+    );
+  });
+
+  it('throws error if directiveResolvers argument is not an object', () => {
+    const jsSchema = makeExecutableSchema({
+      typeDefs: testSchema,
+      resolvers: testResolvers,
+    });
+    return expect(() =>
+      (<any>attachDirectiveResolvers)(jsSchema, 'a'),
+    ).to.throw('Expected directiveResolvers to be of type object, got string');
+  });
 
   it('upper String from resolvers', () => {
     const schema = makeExecutableSchema({

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -31,7 +31,7 @@ import {
   IResolvers,
   IExecutableSchemaDefinition,
   IDirectiveResolvers,
-  NextResolver,
+  NextResolverFn,
 } from '../Interfaces';
 import 'mocha';
 
@@ -2050,7 +2050,7 @@ describe('attachDirectiveResolvers on field', () => {
 
   const directiveResolvers: IDirectiveResolvers<any, any> = {
     lower(
-      next: NextResolver,
+      next: NextResolverFn,
       src: any,
       args: { [argName: string]: any },
       context: any,
@@ -2063,7 +2063,7 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
     upper(
-      next: NextResolver,
+      next: NextResolverFn,
       src: any,
       args: { [argName: string]: any },
       context: any,
@@ -2076,7 +2076,7 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
     catchError(
-      next: NextResolver,
+      next: NextResolverFn,
       src: any,
       args: { [argName: string]: any },
       context: any,

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2198,7 +2198,7 @@ describe('attachDirectives', () => {
       makeExecutableSchema({
         typeDefs: `
           type RootQuery {
-            hello: String @upper @deprecated(reason: "Built-in directive work as normal")
+            hello: String @deprecated(reason: "Built-in directive work as normal") @upper
           }
           schema {
             query: RootQuery

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2034,7 +2034,7 @@ describe('attachDirectives', () => {
         next: NextResolver,
         src: any,
         args: { [argName: string]: any },
-        context: AnalyserNode,
+        context: any,
       ) {
         return next().then((str) => {
           if (typeof(str) === 'string') {

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2020,6 +2020,7 @@ describe('attachDirectives', () => {
     type RootQuery {
       hello: String @upper
       object: TestObject
+      asyncResolver: String @upper
     }
     schema {
       query: RootQuery
@@ -2033,7 +2034,8 @@ describe('attachDirectives', () => {
   const testResolversDirectives = {
     RootQuery: {
       hello: () => 'giau. tran minh',
-      object: () => Promise.resolve(testObject),
+      object: () => testObject,
+      asyncResolver: async () => 'giau. tran minh',
     },
   };
 
@@ -2103,7 +2105,23 @@ describe('attachDirectives', () => {
     const expected = {
       hello: 'giau. tran minh',
     };
+    return graphql(schema, query, {}, {}).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
+  });
 
+  it('If resolver return Promise, keep using it', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: testSchemaWithDirectives,
+      resolvers: testResolversDirectives,
+      directiveResolvers: directiveResolvers,
+    });
+    const query = `{
+      asyncResolver
+    }`;
+    const expected = {
+      asyncResolver: 'GIAU. TRAN MINH',
+    };
     return graphql(schema, query, {}, {}).then(res => {
       expect(res.data).to.deep.equal(expected);
     });

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2192,4 +2192,27 @@ describe('attachDirectives', () => {
      expect(res.data).to.deep.equal(expected);
     });
   });
+
+  it('throws error if trying using undefined Directive', () => {
+    return expect(() => {
+      makeExecutableSchema({
+        typeDefs: `
+          type RootQuery {
+            hello: String @upper
+          }
+          schema {
+            query: RootQuery
+          }
+        `,
+        resolvers: {
+          RootQuery: {
+            hello: () => 'never touch',
+          }
+        },
+        directiveResolvers: directiveResolvers,
+      });
+    }).to.throw(
+      'Directive @upper is undefined. Please define in schema before using',
+    );
+  });
 });

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2011,11 +2011,11 @@ describe('chainResolvers', () => {
 
 
 
-describe('attachDirectives', () => {
+describe('attachDirectives on field', () => {
   const testSchemaWithDirectives = `
-    directive @upper on QUERY | FIELD
-    directive @lower on QUERY | FIELD
-    directive @catchError on QUERY | FIELD
+    directive @upper on FIELD
+    directive @lower on FIELD
+    directive @catchError on FIELD
 
     type TestObject {
       hello: String @upper

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2011,7 +2011,7 @@ describe('chainResolvers', () => {
 
 
 
-describe('attachDirectives on field', () => {
+describe('attachDirectiveResolvers on field', () => {
   const testSchemaWithDirectives = `
     directive @upper on FIELD
     directive @lower on FIELD

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2198,7 +2198,7 @@ describe('attachDirectives', () => {
       makeExecutableSchema({
         typeDefs: `
           type RootQuery {
-            hello: String @upper
+            hello: String @upper @deprecated(reason: "Built-in directive work as normal")
           }
           schema {
             query: RootQuery

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2090,4 +2090,22 @@ describe('attachDirectives', () => {
       expect(res.data).to.deep.equal(expected);
     });
   });
+
+  it('No effect if missing directive resolvers', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: testSchemaWithDirectives,
+      resolvers: testResolversDirectives,
+      directiveResolvers: {}, // Empty resolver
+    });
+    const query = `{
+      hello
+    }`;
+    const expected = {
+      hello: 'giau. tran minh',
+    };
+
+    return graphql(schema, query, {}, {}).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
+  });
 });

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2193,7 +2193,7 @@ describe('attachDirectives', () => {
     });
   });
 
-  it('throws error if trying using undefined Directive', () => {
+  it('throws error if trying use undefined Directive', () => {
     return expect(() => {
       makeExecutableSchema({
         typeDefs: `


### PR DESCRIPTION
**Description**: This PR allows implementing custom directives that can be used for translation, authentication and error tracking.

**API**:
```typescript
const directiveResolvers = {
  // directive resolvers implement
},

const schema = makeExecutableSchema({
  // ...
  directiveResolvers,
});
```

**Example**:
- Using `@upper` directive to upper string from resolver:
```graphql
directive @upper on FIELD
type RootQuery {
  hello: String @upper
}
schema {
  query: RootQuery
}
```
Implement of `@upper` directive.
```typescript
const directiveResolvers = {
  upper(
    next: NextResolver,
    src: any,
    args: { [argName: string]: any },
    context: any,
  ) {
    return next().then((str) => {
      if (typeof(str) === 'string') {
        return str.toUpperCase();
      }
      return str;
    });
  },
}
```

- Using `@auth` directive check roles before run resolver:
```graphql
directive @auth(roles: [String]) on FIELD
type RootQuery {
  secret: String @auth(roles: ["admin"])
}
schema {
  query: RootQuery
}
```
Implement of `@auth` directive.
```typescript
const directiveResolvers = {
  auth(
    next: NextResolver,
    src: any,
    args: { [argName: string]: any },
    context: any,
  ) {
    const { roles } = context; // We asume has roles of current user in context;
    const expectedRoles = args.roles || [];
    if (expectedRoles.length === 0 || expectedRoles.some((r) => roles.includes(r))) {
      // Call next to continues process resolver.
      return next();
    }

    // We has two options here. throw an error or return null (if field is nullable).
    throw new Error(`You are not authorized. Expected roles: ${expectedRoles.join(', ')}`);
  },
}
```

- Catch internal error.
```graphql
directive @errorCatch on FIELD

type RootQuery {
  throwError: String @errorCatch
}
schema {
  query: RootQuery
}
```
Implement of `@errorCatch` directive.
```typescript
// example from: https://github.com/thebigredgeek/apollo-resolvers
import { createError, isInstance } from 'apollo-errors';

const ExposedError = createError('ExposedError', {
  message: 'An unknown error has occurred'
});

const directiveResolvers = {
  errorCatch(
    next: NextResolver,
    src: any,
    args: { [argName: string]: any },
    context: any,
  ) {
    return next().catch((err) => {
      if (!isInstance(err)) {
        throw new ExposedError({
          // overload the message
          message: error.message
        });
      }

      throw err;
    });
  },
}
```
Issue: https://github.com/apollographql/graphql-tools/issues/212
TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
