### PR TITLE
Make error more semantic when schema type has no resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 * ...
+* Make error more semantic when schema type has no resolver [PR #538](https://github.com/apollographql/graphql-tools/pull/538)
 
 ### v2.13.0
 

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -370,6 +370,19 @@ function addResolveFunctionsToSchema(
       );
     }
 
+    // Check that there's a resolver for this schema prop
+    // sometimes it can be an object or a function, so check
+    // that it is not falsey AND is iterable
+    if (
+      !(typeName in resolveFunctions) ||
+      !resolveFunctions[typeName] ||
+      ['function', 'object'].indexOf(typeof resolveFunctions[typeName]) === -1
+    ) {
+      throw new SchemaError(
+        `"${typeName}" is defined in schema but has no resolver.`,
+      );
+    }
+
     Object.keys(resolveFunctions[typeName]).forEach(fieldName => {
       if (fieldName.startsWith('__')) {
         // this is for isTypeOf and resolveType and all the other stuff.

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -123,6 +123,25 @@ describe('generating schema from shorthand', () => {
     ).to.throw(GraphQLError);
   });
 
+  it('throws an error if schema is defined without resolver', () => {
+    expect(() =>
+      (<any>makeExecutableSchema)({ typeDefs: `
+      # A bird species
+      type BirdSpecies {
+        name: String!,
+        wingspan: Int
+      }
+      type RootQuery {
+        species(name: String!): [BirdSpecies]
+      }
+
+      schema {
+        query: RootQuery
+      }
+    `, resolvers: { RootQuery: null } }),
+    ).to.throw('"RootQuery" is defined in schema but has no resolver.');
+  });
+
   it('throws an error if typeDefinitionNodes is neither string nor array nor schema AST', () => {
     expect(() =>
       (<any>makeExecutableSchema)({ typeDefs: {}, resolvers: {} }),


### PR DESCRIPTION
When defining a field in the schema, and that field has no resolver - the resulting error is bland:
```
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /private/tmp/test/node_modules/graphql-tools/src/schemaGenerator.ts:373:12
```

This pull request adds more context to the error so that beginners can debug faster:
```
Error: "Query" is defined in schema but has no resolver.
```

This change will better help beginners debug quicker because they won't need to trace the values of `resolveFunctions` and whether `typeName` within has the appropriate resolver.

TODO:

- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
