### PR TITLE
Update to work with graphql 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - npm config set spin=false
   - npm install -g coveralls
   - npm install
+  - npm install graphql@$GRAPHQL_VERSION
 
 script:
   - npm test
@@ -17,3 +18,7 @@ script:
 
 # Allow Travis tests to run in containers.
 sudo: false
+
+env:
+  - GRAPHQL_VERSION='^0.11'
+  - GRAPHQL_VERSION='^0.12'

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
-    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0"
+    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "devDependencies": {
-    "@types/graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0",
+    "@types/graphql": "0.11.7",
     "@types/chai": "4.0.4",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",
@@ -66,7 +66,7 @@
     "body-parser": "^1.18.2",
     "chai": "^4.1.2",
     "express": "^4.16.2",
-    "graphql": "^0.11.7",
+    "graphql": "^0.12.3",
     "graphql-subscriptions": "^0.5.4",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
-    "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0"
+    "graphql": "^0.11.0 || ^0.12.0"
   },
   "devDependencies": {
-    "@types/graphql": "0.11.7",
     "@types/chai": "4.0.4",
+    "@types/graphql": "0.11.7",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",
     "@types/uuid": "^3.4.3",

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,4 +1,0 @@
-declare module 'graphql/language/blockStringValue' {
-  let blockStringValue: (raw: string) => string;
-  export default blockStringValue;
-}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module 'graphql/language/blockStringValue' {
+  let blockStringValue: (raw: string) => string;
+  export default blockStringValue
+}

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,4 +1,4 @@
 declare module 'graphql/language/blockStringValue' {
   let blockStringValue: (raw: string) => string;
-  export default blockStringValue
+  export default blockStringValue;
 }

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -394,9 +394,7 @@ function addResolveFunctionsToSchema(
       }
 
       if (type instanceof GraphQLEnumType) {
-        // TODO: Remove once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/21786
-        // is inside NPM
-        if (!(type as any).isValidValue(fieldName)) {
+        if (!type.getValue(fieldName)) {
           throw new SchemaError(
             `${typeName}.${fieldName} was defined in resolvers, but enum is not in schema`,
           );

--- a/src/stitching/defaultMergedResolver.ts
+++ b/src/stitching/defaultMergedResolver.ts
@@ -17,7 +17,7 @@ const defaultMergedResolver: GraphQLFieldResolver<any, any> = (
   const errorResult = getErrorsFromParent(parent, responseKey);
   if (errorResult.kind === 'OWN') {
     throw locatedError(
-      errorResult.error.message,
+      new Error(errorResult.error.message),
       info.fieldNodes,
       responsePathAsArray(info.path),
     );

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -81,7 +81,7 @@ export function checkResultAndHandleErrors(
       .map((error: { message: string }) => error.message)
       .join('\n');
     throw locatedError(
-      errorMessage,
+      new Error(errorMessage),
       info.fieldNodes,
       responsePathAsArray(info.path),
     );

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -30,6 +30,8 @@ import {
 import delegateToSchema from './delegateToSchema';
 import typeFromAST from './typeFromAST';
 
+const backcompatOptions = { commentDescriptions: true };
+
 export default function mergeSchemas({
   schemas,
   onTypeConflict,
@@ -64,7 +66,8 @@ export default function mergeSchemas({
     } else if (typeof schema === 'string') {
       let parsedSchemaDocument = parse(schema);
       try {
-        const actualSchema = buildASTSchema(parsedSchemaDocument);
+        // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
+        const actualSchema = (buildASTSchema as any)(parsedSchemaDocument, backcompatOptions);
         actualSchemas.push(actualSchema);
       } catch (e) {
         typeFragments.push(parsedSchemaDocument);
@@ -222,7 +225,8 @@ export default function mergeSchemas({
   });
 
   extensions.forEach(extension => {
-    mergedSchema = extendSchema(mergedSchema, extension);
+    // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
+    mergedSchema = (extendSchema as any)(mergedSchema, extension, backcompatOptions);
   });
 
   addResolveFunctionsToSchema(mergedSchema, fullResolvers);

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -67,7 +67,10 @@ export default function mergeSchemas({
       let parsedSchemaDocument = parse(schema);
       try {
         // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
-        const actualSchema = (buildASTSchema as any)(parsedSchemaDocument, backcompatOptions);
+        const actualSchema = (buildASTSchema as any)(
+          parsedSchemaDocument,
+          backcompatOptions,
+        );
         actualSchemas.push(actualSchema);
       } catch (e) {
         typeFragments.push(parsedSchemaDocument);
@@ -226,7 +229,11 @@ export default function mergeSchemas({
 
   extensions.forEach(extension => {
     // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
-    mergedSchema = (extendSchema as any)(mergedSchema, extension, backcompatOptions);
+    mergedSchema = (extendSchema as any)(
+      mergedSchema,
+      extension,
+      backcompatOptions,
+    );
   });
 
   addResolveFunctionsToSchema(mergedSchema, fullResolvers);

--- a/src/stitching/typeFromAST.ts
+++ b/src/stitching/typeFromAST.ts
@@ -23,14 +23,10 @@ import {
   UnionTypeDefinitionNode,
   valueFromAST,
 } from 'graphql';
-
+//
 // TODO put back import once PR is merged
 // https://github.com/graphql/graphql-js/pull/1165
 // import { getDescription } from 'graphql/utilities/buildASTSchema';
-
-// TODO remove import once PR is merged
-// https://github.com/graphql/graphql-js/pull/1165
-import blockStringValue from 'graphql/language/blockStringValue';
 
 const backcompatOptions = { commentDescriptions: true };
 
@@ -190,7 +186,6 @@ function resolveType(typeRegistry: TypeRegistry, node: TypeNode): GraphQLType {
   }
 }
 
-
 // Code below temporarily copied from graphql/graphql-js pending PR
 // https://github.com/graphql/graphql-js/pull/1165
 
@@ -247,4 +242,60 @@ function getLeadingCommentBlock(node: any): void | string {
     token = token.prev;
   }
   return comments.reverse().join('\n');
+}
+
+/**
+ * Produces the value of a block string from its parsed raw value, similar to
+ * Coffeescript's block string, Python's docstring trim or Ruby's strip_heredoc.
+ *
+ * This implements the GraphQL spec's BlockStringValue() static algorithm.
+ */
+function blockStringValue(rawString: string): string {
+  // Expand a block string's raw value into independent lines.
+  const lines = rawString.split(/\r\n|[\n\r]/g);
+
+  // Remove common indentation from all lines but first.
+  let commonIndent = null;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    const indent = leadingWhitespace(line);
+    if (
+      indent < line.length &&
+      (commonIndent === null || indent < commonIndent)
+    ) {
+      commonIndent = indent;
+      if (commonIndent === 0) {
+        break;
+      }
+    }
+  }
+
+  if (commonIndent) {
+    for (let i = 1; i < lines.length; i++) {
+      lines[i] = lines[i].slice(commonIndent);
+    }
+  }
+
+  // Remove leading and trailing blank lines.
+  while (lines.length > 0 && isBlank(lines[0])) {
+    lines.shift();
+  }
+  while (lines.length > 0 && isBlank(lines[lines.length - 1])) {
+    lines.pop();
+  }
+
+  // Return a string of the lines joined with U+000A.
+  return lines.join('\n');
+}
+
+function leadingWhitespace(str: string): number {
+  let i = 0;
+  while (i < str.length && (str[i] === ' ' || str[i] === '\t')) {
+    i++;
+  }
+  return i;
+}
+
+function isBlank(str: string): boolean {
+  return leadingWhitespace(str) === str.length;
 }

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -69,6 +69,11 @@ type Query {
 }
 `;
 
+let graphql11compat = '';
+if (process.env.GRAPHQL_VERSION === '^0.11') {
+  graphql11compat = '{}';
+}
+
 const linkSchema = `
   # A new type linking the Property type.
   type LinkType {
@@ -104,7 +109,7 @@ const linkSchema = `
     nodes: [Node]
   }
 
-  extend type Customer implements Node
+  extend type Customer implements Node ${graphql11compat}
 `;
 
 testCombinations.forEach(async combination => {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -81,9 +81,6 @@ const linkSchema = `
     id: ID!
   }
 
-  extend type Customer implements Node {
-
-  }
 
   extend type Booking implements Node {
     # The property of the booking.
@@ -106,6 +103,8 @@ const linkSchema = `
     node(id: ID!): Node
     nodes: [Node]
   }
+
+  extend type Customer implements Node
 `;
 
 testCombinations.forEach(async combination => {


### PR DESCRIPTION
`graphql` 0.12 has some major breaking changes that make some features work differently.

Breaking changes to address:

- [x] Descriptions are now strings in the SDL, not comments https://github.com/graphql/graphql-js/pull/927
- [x] Schema AST node names are different now, specifically for extensions https://github.com/graphql/graphql-js/pull/1102
- [x] Check compatibility with `graphql@0.11`
- [ ] Send PR to definitely-typed

After this PR, we should do a major release if it's no longer compatible with 0.11.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
