### PR TITLE
Fix fragment filtering edge case when a type implements multiple interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### vNEXT
 
-* ...
+* Fix a bug where inline fragments got filtered in merged schemas when a type implemented multiple interfaces [PR #546](https://github.com/apollographql/graphql-tools/pull/546)
+
 
 ### v2.17.0
 
@@ -13,7 +14,6 @@
 * Added GraphQL Subscriptions support for schema stitching and `makeRemoteExecutableSchema` [PR #563](https://github.com/apollographql/graphql-tools/pull/563)
 * Make `apollo-link` a direct dependency [PR #561](https://github.com/apollographql/graphql-tools/pull/561)
 * Update tests to use `graphql-js@0.12` docstring format [PR #559](https://github.com/apollographql/graphql-tools/pull/559)
-* Fix a bug where inline fragments got filtered in merged schemas when a type implemented multiple interfaces [PR #546](https://github.com/apollographql/graphql-tools/pull/546)
 
 ### v2.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added GraphQL Subscriptions support for schema stitching and `makeRemoteExecutableSchema` [PR #563](https://github.com/apollographql/graphql-tools/pull/563)
 * Make `apollo-link` a direct dependency [PR #561](https://github.com/apollographql/graphql-tools/pull/561)
 * Update tests to use `graphql-js@0.12` docstring format [PR #559](https://github.com/apollographql/graphql-tools/pull/559)
+* Fix a bug where inline fragments got filtered in merged schemas when a type implemented multiple interfaces [PR #546](https://github.com/apollographql/graphql-tools/pull/546)
 
 ### v2.15.0
 

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -514,7 +514,7 @@ function implementsAbstractType(
     parent instanceof GraphQLInterfaceType &&
     child instanceof GraphQLInterfaceType
   ) {
-    return true
+    return true;
   } else if (
     parent instanceof GraphQLUnionType &&
     child instanceof GraphQLObjectType

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -511,6 +511,11 @@ function implementsAbstractType(
   ) {
     return child.getInterfaces().indexOf(parent) !== -1;
   } else if (
+    parent instanceof GraphQLInterfaceType &&
+    child instanceof GraphQLInterfaceType
+  ) {
+    return true
+  } else if (
     parent instanceof GraphQLUnionType &&
     child instanceof GraphQLObjectType
   ) {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -13,10 +13,12 @@ import {
 import mergeSchemas from '../stitching/mergeSchemas';
 import {
   propertySchema as localPropertySchema,
+  productSchema as localProductSchema,
   bookingSchema as localBookingSchema,
   subscriptionSchema as localSubscriptionSchema,
   remoteBookingSchema,
   remotePropertySchema,
+  remoteProductSchema,
   subscriptionPubSub,
   subscriptionPubSubTrigger,
 } from './testingSchemas';
@@ -24,16 +26,23 @@ import { forAwaitEach } from 'iterall';
 import { makeExecutableSchema } from '../schemaGenerator';
 
 const testCombinations = [
-  { name: 'local', booking: localBookingSchema, property: localPropertySchema },
+  {
+    name: 'local',
+    booking: localBookingSchema,
+    property: localPropertySchema,
+    product: localProductSchema,
+  },
   {
     name: 'remote',
     booking: remoteBookingSchema,
     property: remotePropertySchema,
+    product: remoteProductSchema,
   },
   {
     name: 'hybrid',
     booking: localBookingSchema,
     property: remotePropertySchema,
+    product: localProductSchema,
   },
 ];
 
@@ -92,7 +101,6 @@ let linkSchema = `
   interface Node {
     id: ID!
   }
-
 
   extend type Booking implements Node {
     """
@@ -208,16 +216,19 @@ testCombinations.forEach(async combination => {
   describe('merging ' + combination.name, () => {
     let mergedSchema: GraphQLSchema,
       propertySchema: GraphQLSchema,
+      productSchema: GraphQLSchema,
       bookingSchema: GraphQLSchema;
 
     before(async () => {
       propertySchema = await combination.property;
       bookingSchema = await combination.booking;
+      productSchema = await combination.product;
 
       mergedSchema = mergeSchemas({
         schemas: [
           propertySchema,
           bookingSchema,
+          productSchema,
           scalarTest,
           enumTest,
           linkSchema,
@@ -1786,6 +1797,39 @@ bookingById(id: $b1) {
       //     },
       //   });
       // });
+
+      it('multi-interface filter', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              products {
+                id
+                __typename
+                ... on Sellable {
+                  price
+                }
+              }
+            }
+          `,
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            products: [
+              {
+                id: 'pd1',
+                __typename: 'SimpleProduct',
+                price: 100,
+              },
+              {
+                id: 'pd2',
+                __typename: 'DownloadableProduct',
+              },
+            ],
+          },
+        });
+      });
 
       it('arbitrary transforms that return interfaces', async () => {
         const result = await graphql(


### PR DESCRIPTION
@freiksenet: I had to pin graphql-tools to 2.7.1 because since the changes in https://github.com/apollographql/graphql-tools/pull/470, I have an issue with inline fragments on types that implement multiple interfaces.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
