### PR TITLE
Field directives can override source and args of next resolver

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -85,10 +85,15 @@ export type IFieldIteratorFn = (
   fieldName: string,
 ) => void;
 
-export type NextResolverFn = () => Promise<any>;
-export type DirectiveResolverFn<TSource, TContext> = (
-  next: NextResolverFn,
+export type NextResolverFn<TSource> = (
   source: TSource,
+  inputArgs: { [argName: string]: any },
+) => Promise<any>;
+
+export type DirectiveResolverFn<TSource, TContext> = (
+  next: NextResolverFn<TSource>,
+  source: TSource,
+  inputArgs: { [argName: string]: any },
   args: { [argName: string]: any },
   context: TContext,
   info: GraphQLResolveInfo,

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -86,17 +86,17 @@ export type IFieldIteratorFn = (
 ) => void;
 
 export type NextResolverFn<TSource> = (
-  source: TSource,
-  inputArgs: { [argName: string]: any },
+  source?: TSource,
+  inputArgs?: { [argName: string]: any },
 ) => Promise<any>;
 
 export type DirectiveResolverFn<TSource, TContext> = (
   next: NextResolverFn<TSource>,
   source: TSource,
-  inputArgs: { [argName: string]: any },
-  args: { [argName: string]: any },
+  directiveArgs: { [argName: string]: any },
   context: TContext,
   info: GraphQLResolveInfo,
+  inputArgs: { [argName: string]: any },
 ) => any;
 
 export interface IDirectiveResolvers<TSource, TContext> {

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -688,11 +688,11 @@ function attachDirectiveResolvers(
         const directiveArgs = getArgumentValues(Directive, directive);
 
         field.resolve = (...args: any[]) => {
-          const [source, , context, info] = args;
+          const [source, inputArgs, context, info] = args;
           return resolver(
-            () => {
+            (source, inputArgs) => {
               try {
-                const promise = originalResolver.call(field, ...args);
+                const promise = originalResolver.call(field, source, inputArgs, ...args.slice(2));
                 if (promise instanceof Promise) {
                   return promise;
                 }
@@ -702,6 +702,7 @@ function attachDirectiveResolvers(
               }
             },
             source,
+            inputArgs,
             directiveArgs,
             context,
             info,

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -690,9 +690,13 @@ function attachDirectiveResolvers(
         field.resolve = (...args: any[]) => {
           const [source, inputArgs, context, info] = args;
           return resolver(
-            (source, inputArgs) => {
+            (_source, _inputArgs) => {
               try {
-                const promise = originalResolver.call(field, source, inputArgs, ...args.slice(2));
+                const promise = originalResolver.call(
+                  field,
+                  typeof _source === 'undefined' ? source : _source,
+                  typeof _inputArgs === 'undefined' ? inputArgs : _inputArgs,
+                  ...args.slice(2));
                 if (promise instanceof Promise) {
                   return promise;
                 }
@@ -702,10 +706,10 @@ function attachDirectiveResolvers(
               }
             },
             source,
-            inputArgs,
             directiveArgs,
             context,
             info,
+            inputArgs,
           );
         };
       }

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2062,12 +2062,13 @@ describe('attachDirectiveResolvers on field', () => {
 
   const directiveResolvers: IDirectiveResolvers<any, any> = {
     lower(
-      next: NextResolverFn,
+      next: NextResolverFn<any>,
       src: any,
+      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next().then(str => {
+      return next(src, inputArgs).then(str => {
         if (typeof str === 'string') {
           return str.toLowerCase();
         }
@@ -2075,12 +2076,13 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
     upper(
-      next: NextResolverFn,
+      next: NextResolverFn<any>,
       src: any,
+      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next().then(str => {
+      return next(src, inputArgs).then(str => {
         if (typeof str === 'string') {
           return str.toUpperCase();
         }
@@ -2088,12 +2090,13 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
     default(
-      next: NextResolverFn,
+      next: NextResolverFn<any>,
       src: any,
+      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next().then(res => {
+      return next(src, inputArgs).then(res => {
         if (undefined === res) {
           return args.value;
         }
@@ -2101,12 +2104,13 @@ describe('attachDirectiveResolvers on field', () => {
       });
     },
     catchError(
-      next: NextResolverFn,
+      next: NextResolverFn<any>,
       src: any,
+      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next().catch(error => {
+      return next(src, inputArgs).catch(error => {
         return error.message;
       });
     },

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2064,11 +2064,10 @@ describe('attachDirectiveResolvers on field', () => {
     lower(
       next: NextResolverFn<any>,
       src: any,
-      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next(src, inputArgs).then(str => {
+      return next().then(str => {
         if (typeof str === 'string') {
           return str.toLowerCase();
         }
@@ -2078,11 +2077,10 @@ describe('attachDirectiveResolvers on field', () => {
     upper(
       next: NextResolverFn<any>,
       src: any,
-      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next(src, inputArgs).then(str => {
+      return next().then(str => {
         if (typeof str === 'string') {
           return str.toUpperCase();
         }
@@ -2092,11 +2090,10 @@ describe('attachDirectiveResolvers on field', () => {
     default(
       next: NextResolverFn<any>,
       src: any,
-      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next(src, inputArgs).then(res => {
+      return next().then(res => {
         if (undefined === res) {
           return args.value;
         }
@@ -2106,11 +2103,10 @@ describe('attachDirectiveResolvers on field', () => {
     catchError(
       next: NextResolverFn<any>,
       src: any,
-      inputArgs: { [argName: string]: any },
       args: { [argName: string]: any },
       context: any,
     ) {
-      return next(src, inputArgs).catch(error => {
+      return next().catch(error => {
         return error.message;
       });
     },


### PR DESCRIPTION
I would like to add `@mutate` directive for `FIELD_DEFINITION` to make GraphQL support nested mutation.

Schema
```graphql
type User {
  id: ID!
  username: String
  articlesCount: Int
  update(input: UserInput): Boolean @mutate
  addArticle(input: ArticleInput): Article @mutate
}
Query {
  user(id: ID!): User
}
```

Query
```graphql
query {
  user(id: $id) {
    update(input: $input)
    addArticle(input: $articleInput) {
      title
    }
    username
    articlesCount
  }
}
```

GraphQL will execute `update` and `follow` sequentially and then evaluate `username` and `followingCount` in parallel.
But, I want that `update` resolver can return the new `source` object and give it to next resolver i.e. `follow`. And finally give to `username` and `followingCount` resolvers.

```js
const userResolvers = {
  update: (user, { input }, ctx) => {
    return user.update(input).then(newUser => ({source: newUser, result: true}))
  }
  addArticle: (user, { input }, ctx) => {
    return user.articles.create(input).then(article => {
      return user.reload().then(newUser => ({source: newUser, result: article}))
    })
  }
}
```


To make this happen, `directiveResolver` must have the ability to send `source` to `NextResolver` which the changes are for.