### PR TITLE
fix: correct the dependency issue in typescript caused by #445

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
     "apollo-utilities": "^1.0.1",
+    "apollo-link": "^1.0.0",
     "deprecated-decorator": "^0.1.6",
     "uuid": "^3.1.0"
   },
@@ -62,7 +63,6 @@
     "@types/node": "^8.0.47",
     "@types/uuid": "^3.4.3",
     "@types/zen-observable": "^0.5.3",
-    "apollo-link": "^1.0.0",
     "body-parser": "^1.18.2",
     "chai": "^4.1.2",
     "express": "^4.16.2",


### PR DESCRIPTION
This PR aims to fix #472. It reverts the change made in #445 that apollo-link was made as a development dependency instead of a direct dependency. As a result, it causes a complain in typescript. According to the [guideline](http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies), it should be listed as a direct dependency.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change