### PR TITLE
Include astNode in schema recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added GraphQL Subscriptions support for schema stitching and `makeRemoteExecutableSchema` [PR #563](https://github.com/apollographql/graphql-tools/pull/563)
 * Make `apollo-link` a direct dependency [PR #561](https://github.com/apollographql/graphql-tools/pull/561)
 * Update tests to use `graphql-js@0.12` docstring format [PR #559](https://github.com/apollographql/graphql-tools/pull/559)
+* Include `astNode` property in schema recreation
 
 ### v2.15.0
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -63,7 +63,7 @@ export function recreateCompositeType(
     return new GraphQLInputObjectType({
       name: type.name,
       description: type.description,
-      astNode: type.astNode
+      astNode: type.astNode,
       fields: () => inputFieldMapToFieldConfigMap(type.getFields(), registry),
     });
   } else {

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -34,6 +34,7 @@ export function recreateCompositeType(
       name: type.name,
       description: type.description,
       isTypeOf: type.isTypeOf,
+      astNode: type.astNode,
       fields: () => fieldMapToFieldConfigMap(fields, registry),
       interfaces: () => interfaces.map(iface => registry.resolveType(iface)),
     });
@@ -43,6 +44,7 @@ export function recreateCompositeType(
     return new GraphQLInterfaceType({
       name: type.name,
       description: type.description,
+      astNode: type.astNode,
       fields: () => fieldMapToFieldConfigMap(fields, registry),
       resolveType: (parent, context, info) =>
         resolveFromParentTypename(parent, info.schema),
@@ -51,6 +53,7 @@ export function recreateCompositeType(
     return new GraphQLUnionType({
       name: type.name,
       description: type.description,
+      astNode: type.astNode,
       types: () =>
         type.getTypes().map(unionMember => registry.resolveType(unionMember)),
       resolveType: (parent, context, info) =>
@@ -60,6 +63,7 @@ export function recreateCompositeType(
     return new GraphQLInputObjectType({
       name: type.name,
       description: type.description,
+      astNode: type.astNode
       fields: () => inputFieldMapToFieldConfigMap(type.getFields(), registry),
     });
   } else {


### PR DESCRIPTION
`mergeSchemas` does not set `astNode` properties, when recreating types.
But `CacheControlExtension.willResolveField` uses the `astNode` property in order to get the `cacheControl` directives.

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
