### PR TITLE
Add `directiveResolvers` param to `mergeSchemas`

### DIFF
--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -671,6 +671,9 @@ function attachDirectiveResolvers(
     );
   }
   forEachField(schema, (field: GraphQLField<any, any>) => {
+    if (!field.astNode) {
+      return;
+    }
     const directives = field.astNode.directives;
     directives.forEach((directive: DirectiveNode) => {
       const directiveName = directive.name.value;

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -92,6 +92,7 @@ function fieldToFieldConfig(
     resolve: defaultMergedResolver,
     description: field.description,
     deprecationReason: field.deprecationReason,
+    astNode: field.astNode
   };
 }
 
@@ -140,5 +141,6 @@ function inputFieldToFieldConfig(
     type: registry.resolveType(field.type),
     defaultValue: field.defaultValue,
     description: field.description,
+    astNode: field.astNode
   };
 }

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -226,7 +226,7 @@ if (process.env.GRAPHQL_VERSION === '^0.11') {
   `;
 }
 
-testCombinations.forEach(async combination => {
+testCombinations.forEach(async (combination, iteration) => {
   describe('merging ' + combination.name, () => {
     let mergedSchema: GraphQLSchema,
       propertySchema: GraphQLSchema,
@@ -1930,6 +1930,27 @@ bookingById(id: $b1) {
           },
         });
       });
+    });
+
+    it('Should allow wrapping merged schema with directiveResolvers', async () => {
+      // TODO this only works for local schemas
+      if (iteration === 0) {
+        const directiveResolvers: {[key: string]: () => any} = {
+          disabled: (...args: Array<any>) => null
+        };
+        const newSchema = mergeSchemas({
+          schemas: ['directive @disabled on FIELD_DEFINITION', mergedSchema],
+          directiveResolvers
+        });
+
+        const result = await graphql(
+          newSchema,
+          `query {
+            dateTimeTest
+          }`
+        );
+        expect(result.data.dateTimeTest).to.equal(null);
+      }
     });
 
     describe('regression', () => {

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -275,7 +275,7 @@ const propertyRootTypeDefs = `
     propertyById(id: ID!): Property
     properties(limit: Int): [Property!]
     contextTest(key: String!): String
-    dateTimeTest: DateTime
+    dateTimeTest: DateTime @disabled(yes: true)
     jsonTest(input: JSON): JSON
     interfaceTest(kind: TestInterfaceKind): TestInterface
     errorTest: String
@@ -288,6 +288,7 @@ const propertyRootTypeDefs = `
 const propertyAddressTypeDefs = `
   scalar DateTime
   scalar JSON
+  directive @disabled(yes: Boolean) on FIELD_DEFINITION
 
   ${addressTypeDef}
   ${propertyAddressTypeDef}


### PR DESCRIPTION
Hey guys, 
This PR adds the ability to wrap a merged schema with directive resolvers. This is beneficial say, when you want to wrap your entire merged schema with a common `@auth` directive. 

```javascript
mergeSchemas({ schemas, resolvers, directiveResolvers })
```


However, this currently doesn't work with remote schemas (because directive information is lost when we printSchema https://github.com/graphql/graphql-js/issues/869), although I am trying to get that working to. Thought I would get some feedback first before going through with the whole thing 😄 

TODO:
- Update 
- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change
