### PR TITLE
Also recreate astNode for fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Also recreate `astNode` property for fields, not only types, when recreating schemas.
 
 ### v2.18.0
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -92,6 +92,7 @@ function fieldToFieldConfig(
     resolve: defaultMergedResolver,
     description: field.description,
     deprecationReason: field.deprecationReason,
+    astNode: field.astNode,
   };
 }
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -141,5 +141,6 @@ function inputFieldToFieldConfig(
     type: registry.resolveType(field.type),
     defaultValue: field.defaultValue,
     description: field.description,
+    astNode: field.astNode,
   };
 }


### PR DESCRIPTION
In a [previous commit](https://github.com/apollographql/graphql-tools/commit/fd9f6260faa779b2bfc12f1f707cdf2b778d306b) we added the `astNode` property in the `reacreateCompositeType` function. That resulted in cache control working with schema stitching but only for GraphQL Types. By recreating the `astNode` prop also in `fieldToFieldConfig` cache control also works for fields. This is required for caching fields and hence queries.

See also #505.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change
