### PR TITLE
Remove graphql-subscriptions from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "chai": "^4.1.2",
     "express": "^4.16.2",
     "graphql": "^0.12.3",
-    "graphql-subscriptions": "^0.5.4",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",
     "iterall": "^1.1.3",


### PR DESCRIPTION
The same module, `graphql-subscriptions` is specified in both `dependencies` and `devDependencies`.

On some versions of npm (we've seen it in 4.6.1) this can cause `npm prune --production` to erroneously remove the `graphql-subscriptions` module, causing a crash on startup when a server uses `makeExecutableSchema`.

Specifying `graphql-subscriptions` as a direct dependency of the project consuming `graphql-tools` is usable as a workaround.