### PR TITLE
Handle aliases when using `stitching/delegateToSchema`

### DIFF
--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -192,6 +192,23 @@ export function createDocument(
   return newDoc;
 }
 
+function stripAliases(selectionSet: SelectionSetNode): SelectionSetNode {
+  return visit(selectionSet, {
+    [Kind.FIELD]: {
+      enter(node: FieldNode): null | undefined | FieldNode {
+        if (!node) {
+          return node;
+        }
+
+        return {
+          ...node,
+          alias: null,
+        };
+      },
+    },
+  });
+}
+
 function processRootField(
   selection: FieldNode,
   rootFieldName: string,

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -257,7 +257,7 @@ function processRootField(
       kind: Kind.FIELD,
       alias: null,
       arguments: [...filteredExistingArguments, ...missingArguments],
-      selectionSet: selection.selectionSet,
+      selectionSet: stripAliases(selection.selectionSet),
       name: {
         kind: Kind.NAME,
         value: rootFieldName,


### PR DESCRIPTION
# Problem

Aliases do not work when using `delegateToSchema`. The original aliased fields are queried in the delegated schema with the alias and then when GraphQL executes it's default resolver, the concrete value will not be found so `null` will be returned.

See https://github.com/graphql/graphql-js/blob/master/src/execution/execute.js#L1318-L1332

# Solution

Since the default resolver expects the concrete values to exist and will then map aliases to those, we should remove all aliases in delegated schema execution. This is already being done for the root field; this PR will remove all aliases in the entire query.

# Tests

~There are no tests that I could find around `delegateToSchema`. If I'm mistaken, please point me in the right direction and I'd be happy to add any and all tests that the maintainers want.~

This causes lots of tests to fail. I'm investigating now and would appreciate any and all feedback/help :)

---

Resolves issue https://github.com/apollographql/graphql-tools/issues/519