### PR TITLE
fix(subscriptions): The subscription resolvers were firing too often

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+### v2.19.1
+* Fix duplicate subscriptions for schema stitching [PR #609](https://github.com/apollographql/graphql-tools/pull/609)
+
 ### v2.19.0
 
 * Also recreate `astNode` property for fields, not only types, when recreating schemas. [PR #580](https://github.com/apollographql/graphql-tools/pull/580)

--- a/package.json
+++ b/package.json
@@ -48,10 +48,9 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
-    "apollo-utilities": "^1.0.1",
     "apollo-link": "^1.0.0",
+    "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
-    "graphql-subscriptions": "^0.5.6",
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
@@ -68,6 +67,7 @@
     "chai": "^4.1.2",
     "express": "^4.16.2",
     "graphql": "^0.12.3",
+    "graphql-subscriptions": "^0.5.6",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",
     "iterall": "^1.1.3",

--- a/src/stitching/observableToAsyncIterable.ts
+++ b/src/stitching/observableToAsyncIterable.ts
@@ -1,0 +1,77 @@
+import { Observable } from 'apollo-link';
+import { $$asyncIterator } from 'iterall';
+type Callback = (value?: any) => any;
+
+export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIterator<T> {
+  const pullQueue: Callback[] = [];
+  const pushQueue: any[] = [];
+
+  let listening = true;
+
+  const pushValue = ({ data }: any) => {
+    if (pullQueue.length !== 0) {
+      pullQueue.shift()({ value: data, done: false });
+    } else {
+      pushQueue.push({ value: data });
+    }
+  };
+
+  const pushError = (error: any) => {
+    if (pullQueue.length !== 0) {
+      pullQueue.shift()({ value: { errors: [error] }, done: false });
+    } else {
+      pushQueue.push({ value: { errors: [error] } });
+    }
+  };
+
+  const pullValue = () => {
+    return new Promise(resolve => {
+      if (pushQueue.length !== 0) {
+        const element = pushQueue.shift();
+        // either {value: {errors: [...]}} or {value: ...}
+        resolve({
+          ...element,
+          done: false,
+        });
+      } else {
+        pullQueue.push(resolve);
+      }
+    });
+  };
+
+  const subscription = observable.subscribe({
+    next(value: any) {
+      pushValue(value);
+    },
+    error(err: Error) {
+      pushError(err);
+    },
+  });
+
+  const emptyQueue = () => {
+    if (listening) {
+      listening = false;
+      subscription.unsubscribe();
+      pullQueue.forEach(resolve => resolve({ value: undefined, done: true }));
+      pullQueue.length = 0;
+      pushQueue.length = 0;
+    }
+  };
+
+  return {
+    async next() {
+      return listening ? pullValue() : this.return();
+    },
+    return() {
+      emptyQueue();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw(error) {
+      emptyQueue();
+      return Promise.reject(error);
+    },
+    [$$asyncIterator]() {
+      return this;
+    },
+  };
+}

--- a/src/test/testMakeRemoteExecutableSchema.ts
+++ b/src/test/testMakeRemoteExecutableSchema.ts
@@ -80,6 +80,6 @@ describe('remote subscriptions', () => {
     setTimeout(() => {
       expect(notificationCnt).to.eq(2);
       done();
-    }, 150);
+    }, 0);
   });
 });

--- a/src/test/testMakeRemoteExecutableSchema.ts
+++ b/src/test/testMakeRemoteExecutableSchema.ts
@@ -33,16 +33,53 @@ describe('remote subscriptions', () => {
 
     let notificationCnt = 0;
     subscribe(schema, subscription).then(results =>
-      forAwaitEach(
-        results as AsyncIterable<ExecutionResult>,
-        (result: ExecutionResult) => {
-          expect(result).to.have.property('data');
-          expect(result.data).to.deep.equal(mockNotification);
-          !notificationCnt++ ? done() : null;
-        },
-      ),
+      forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
+        expect(result).to.have.property('data');
+        expect(result.data).to.deep.equal(mockNotification);
+        !notificationCnt++ ? done() : null;
+      }),
     );
 
     subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+  });
+
+  it('should work without triggering multiple times per notification', done => {
+    const mockNotification = {
+      notifications: {
+        text: 'Hello world',
+      },
+    };
+
+    const subscription = parse(`
+      subscription Subscription {
+        notifications {
+          text
+        }
+      }
+    `);
+
+    let notificationCnt = 0;
+    subscribe(schema, subscription).then(results =>
+      forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
+        expect(result).to.have.property('data');
+        expect(result.data).to.deep.equal(mockNotification);
+        notificationCnt++;
+      }),
+    );
+
+    subscribe(schema, subscription).then(results =>
+      forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
+        expect(result).to.have.property('data');
+        expect(result.data).to.deep.equal(mockNotification);
+      }),
+    );
+
+    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+
+    setTimeout(() => {
+      expect(notificationCnt).to.eq(2);
+      done();
+    }, 150);
   });
 });


### PR DESCRIPTION
The underlying subscription in a remote schema was not terminated properly, causing memory leaks. In
addition, multiple subscriptions caused duplicate payloads. Both are fixed by removing the PubSub
dependency and directly transforming the Observer returned by the ApolloLink to an async iterable.
This allows the async iterable to propagate to the underlying observable to cancel the subscription
once the subscription is not needed anymore.

Fixing https://github.com/graphcool/graphql-yoga/issues/101
