### PR TITLE
fix(stitching): error.path could be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * ...
 
+* Fix `error.path` could be `undefined` for schema stitching [PR #617](https://github.com/apollographql/graphql-tools/pull/617)
+
 ### v2.20.0
 
 * Recreate enums and scalars for more consistent behaviour of merged schemas [PR #613](https://github.com/apollographql/graphql-tools/pull/613)

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -11,6 +11,7 @@ export function annotateWithChildrenErrors(
     if (Array.isArray(object)) {
       const byIndex = {};
       childrenErrors.forEach(error => {
+        if (!error.path) { return; }
         const index = error.path[1];
         const current = byIndex[index] || [];
         current.push({
@@ -27,7 +28,7 @@ export function annotateWithChildrenErrors(
         ...object,
         [ERROR_SYMBOL]: childrenErrors.map(error => ({
           ...error,
-          path: error.path.slice(1),
+          ...(error.path ? { path: error.path.slice(1) } : {}),
         })),
       };
     }


### PR DESCRIPTION
Fix `error.path` could be `undefined` for schema stitching

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.
