### PR TITLE
fix: pass typeResolvers in mocking.md

### DIFF
--- a/docs/source/mocking.md
+++ b/docs/source/mocking.md
@@ -186,7 +186,8 @@ const typeResolvers = {
 }
 
 const schema = makeExecutableSchema({
-  typeDefs
+  typeDefs,
+  typeResolvers
 })
 
 addMockFunctionsToSchema({


### PR DESCRIPTION
Same as https://github.com/apollographql/tools-docs/pull/141 which apparently never landed in but is still an issue 🐱 

> Currently the typeResolvers aren't used at all in the example, while they should be passed to makeExecutableSchema as seen in https://github.com/apollographql/graphql-tools/blob/5c5418cec88f1d5520eccc1d2e6dfaa511547e4d/src/schemaGenerator.ts#L99

