### PR TITLE
fix(schema-stitching): Pass through error when coming from apollo-link-http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Pass through apollo-link-http errors to originalError [PR #621](https://github.com/apollographql/graphql-tools/pull/621)
 
 ### v2.20.1
 

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -103,7 +103,7 @@ export function checkResultAndHandleErrors(
 
 function concatErrors(errors: Error[]) {
   return errors
-    .map((error: { message: string }) => error.message)
+    .map(error => error.message)
     .join('\n');
 }
 

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -78,11 +78,14 @@ export function checkResultAndHandleErrors(
       : info.fieldName;
   }
   if (result.errors && (!result.data || result.data[responseKey] == null)) {
-    const errorMessage = result.errors
-      .map((error: { message: string }) => error.message)
-      .join('\n');
+    // apollo-link-http & http-link-dataloader need the
+    // result property to be passed through for better error handling.
+    // If there is only one error, which contains a result property, pass the error through
+    const newError = result.errors.length === 1 && hasResult(result.errors[0])
+      ? result.errors[0] : new Error(concatErrors(result.errors));
+
     throw locatedError(
-      new Error(errorMessage),
+      newError,
       info.fieldNodes,
       responsePathAsArray(info.path),
     );
@@ -96,4 +99,14 @@ export function checkResultAndHandleErrors(
     }
     return resultObject;
   }
+}
+
+function concatErrors(errors: Error[]) {
+  return errors
+    .map((error: { message: string }) => error.message)
+    .join('\n');
+}
+
+function hasResult(error: any) {
+  return error.result || (error.originalError && error.originalError.result);
 }


### PR DESCRIPTION
This is needed in order to handle custom properties on the GraphQLError object, like `code` or
`requestId`.

The problem is surfacing here: https://github.com/graphql-binding/graphql-binding/issues/45