### PR TITLE
Make iterall a runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Make iterall a runtime dependency [PR #627](https://github.com/apollographql/graphql-tools/pull/627)
 
 ### v2.20.2
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "apollo-link": "^1.0.0",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
+    "iterall": "^1.1.3",    
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
@@ -70,7 +71,6 @@
     "graphql-subscriptions": "^0.5.6",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",
-    "iterall": "^1.1.3",
     "mocha": "^4.0.1",
     "prettier": "^1.7.4",
     "remap-istanbul": "0.9.6",


### PR DESCRIPTION
Fixes #625

Iterall is used in runtime code (e.g. https://github.com/apollographql/graphql-tools/blob/2868fe26266623dcb4a906c6450ccedbd10d62dc/src/stitching/observableToAsyncIterable.ts) but isn't a dependency. That means unless you happen to have it installed for some other reason, graphql-tools is unusable right now.
