### PR TITLE
Maintain original errors where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNEXT
 
+* When concatenating errors maintain a reference to the original for use downstream [Issue #480](https://github.com/apollographql/graphql-tools/issues/480) [PR #637](https://github.com/apollographql/graphql-tools/pull/637)
+
+
 ### v2.21.0
 
 * Make iterall a runtime dependency [PR #627](https://github.com/apollographql/graphql-tools/pull/627)

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -77,6 +77,14 @@ export function getErrorsFromParent(
   };
 }
 
+class CombinedError extends Error {
+  public errors: Error[];
+  constructor(message: string, errors: Error[]) {
+    super(message);
+    this.errors = errors;
+  }
+}
+
 export function checkResultAndHandleErrors(
   result: any,
   info: GraphQLResolveInfo,
@@ -94,7 +102,7 @@ export function checkResultAndHandleErrors(
     const newError =
       result.errors.length === 1 && hasResult(result.errors[0])
         ? result.errors[0]
-        : new Error(concatErrors(result.errors));
+        : new CombinedError(concatErrors(result.errors), result.errors);
 
     throw locatedError(
       newError,

--- a/src/test/testErrors.ts
+++ b/src/test/testErrors.ts
@@ -17,7 +17,7 @@ class ErrorWithResult extends Error {
   }
 }
 
-describe.only('Errors', () => {
+describe('Errors', () => {
   describe('checkResultAndHandleErrors', () => {
     it('persists single error with a result', done => {
       const result = {

--- a/src/test/testErrors.ts
+++ b/src/test/testErrors.ts
@@ -1,0 +1,76 @@
+import { assert } from 'chai';
+import {
+  GraphQLResolveInfo
+} from 'graphql';
+import {
+  checkResultAndHandleErrors
+} from '../stitching/errors';
+
+import 'mocha';
+
+
+class ErrorWithResult extends Error {
+  public result: any;
+  constructor(message: string, result: any) {
+    super(message);
+    this.result = result;
+  }
+}
+
+describe.only('Errors', () => {
+  describe('checkResultAndHandleErrors', () => {
+    it('persists single error with a result', done => {
+      const result = {
+        errors: [new ErrorWithResult('Test error', 'result')]
+      };
+      try {
+        checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');
+      } catch (e) {
+        assert.equal(e.message, 'Test error');
+        assert.isUndefined(e.originalError.errors);
+        done();
+      }
+    });
+
+    it('persists original errors without a result', done => {
+      const result = {
+        errors: [new Error('Test error')]
+      };
+      try {
+        checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');
+      } catch (e) {
+        assert.equal(e.message, 'Test error');
+        assert.isNotEmpty(e.originalError);
+        assert.isNotEmpty(e.originalError.errors);
+        assert.lengthOf(e.originalError.errors, result.errors.length);
+        result.errors.forEach((error, i) => {
+          assert.deepEqual(e.originalError.errors[i], error);
+        });
+
+        done();
+      }
+    });
+
+    it('combines errors and perists the original errors', done => {
+      const result = {
+        errors: [
+          new Error('Error1'),
+          new Error('Error2')
+        ]
+      };
+      try {
+        checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');
+      } catch (e) {
+        assert.equal(e.message, 'Error1\nError2');
+        assert.isNotEmpty(e.originalError);
+        assert.isNotEmpty(e.originalError.errors);
+        assert.lengthOf(e.originalError.errors, result.errors.length);
+        result.errors.forEach((error, i) => {
+          assert.deepEqual(e.originalError.errors[i], error);
+        });
+
+        done();
+      }
+    });
+  });
+});

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -6,3 +6,4 @@ import './testMocking';
 import './testResolution';
 import './testMakeRemoteExecutableSchema';
 import './testMergeSchemas';
+import './testErrors';


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This is to complete and address the PR previously opened here: https://github.com/apollographql/graphql-tools/pull/485

This is to address the issue logged here: https://github.com/apollographql/graphql-tools/issues/480

Currently, if schema stitching is used, any local errors will be swallowed and "recreated", thereby losing the original stack trace and making it very hard to debug. Along the same lines as what @alexFaunt proposed, we will now attach the original errors to the error object.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.
