### PR TITLE
[docs] makeExecutableSchema does not require resolvers

### DIFF
--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -316,7 +316,7 @@ This [GraphQL schema language cheat sheet](https://raw.githubusercontent.com/sog
 
 <h3 id="makeExecutableSchema" title="makeExecutableSchema">makeExecutableSchema(options)</h3>
 
-`makeExecutableSchema` takes a single argument: an object of options. Only the `typeDefs` and `resolvers` options are required.
+`makeExecutableSchema` takes a single argument: an object of options. Only the `typeDefs` option is required.
 
 ```
 import { makeExecutableSchema } from 'graphql-tools';
@@ -332,7 +332,7 @@ const jsSchema = makeExecutableSchema({
 
 - `typeDefs` is a required argument and should be an array of GraphQL schema language strings or a function that takes no arguments and returns an array of GraphQL schema language strings. The order of the strings in the array is not important, but it must include a schema definition.
 
-- `resolvers` is a required argument and should be an object that follows the pattern explained in [article on resolvers](http://dev.apollodata.com/tools/graphql-tools/resolvers.html).
+- `resolvers` is an optional argument _(empty object by default)_ and should be an object that follows the pattern explained in [article on resolvers](http://dev.apollodata.com/tools/graphql-tools/resolvers.html).
 
 - `logger` is an optional argument, which can be used to print errors to the server console that are usually swallowed by GraphQL. The `logger` argument should be an object with a `log` function, eg. `const logger = { log: (e) => console.log(e) }`
 


### PR DESCRIPTION
As it can be seen [in the code](https://github.com/apollographql/graphql-tools/blob/master/src/schemaGenerator.ts#L116), the `resolvers` option has a default value so it's not required argument.