### PR TITLE
Update apollo-link to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
-    "apollo-link": "~1.1.0",
+    "apollo-link": "^1.2.1",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
     "iterall": "^1.1.3",


### PR DESCRIPTION
This brings in [`zen-observable-ts`](http://npmjs.org/package/zen-observable-ts), a TypeScript wrapper around the [`zen-observable`](http://npmjs.org/package/zen-observable) npm package, implemented by @evans: https://github.com/apollographql/apollo-link/pull/515