### PR TITLE
Improved generic typings for makeExecutableSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### vNEXT
 
 * When concatenating errors maintain a reference to the original for use downstream [Issue #480](https://github.com/apollographql/graphql-tools/issues/480) [PR #637](https://github.com/apollographql/graphql-tools/pull/637)
-
+* Improve generic typings for several resolver-related interfaces [PR #662](https://github.com/apollographql/graphql-tools/pull/662)
 
 ### v2.21.0
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -21,11 +21,11 @@ export interface IResolverValidationOptions {
   allowResolversNotInSchema?: boolean;
 }
 
-export interface IResolverOptions {
-  resolve?: IFieldResolver<any, any>;
-  subscribe?: IFieldResolver<any, any>;
-  __resolveType?: GraphQLTypeResolver<any, any>;
-  __isTypeOf?: GraphQLIsTypeOfFn<any, any>;
+export interface IResolverOptions<TSource = any, TContext = any> {
+  resolve?: IFieldResolver<TSource, TContext>;
+  subscribe?: IFieldResolver<TSource, TContext>;
+  __resolveType?: GraphQLTypeResolver<TSource, TContext>;
+  __isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
 }
 
 export type MergeInfo = {
@@ -47,14 +47,14 @@ export type IFieldResolver<TSource, TContext> = (
 
 export type ITypedef = (() => ITypedef[]) | string | DocumentNode;
 export type ITypeDefinitions = ITypedef | ITypedef[];
-export type IResolverObject = {
-  [key: string]: IFieldResolver<any, any> | IResolverOptions;
+export type IResolverObject<TSource = any, TContext = any> = {
+  [key: string]: IFieldResolver<TSource, TContext> | IResolverOptions;
 };
 export type IEnumResolver = { [key: string]: string | number };
-export interface IResolvers {
+export interface IResolvers<TSource = any, TContext = any> {
   [key: string]:
     | (() => any)
-    | IResolverObject
+    | IResolverObject<TSource, TContext>
     | GraphQLScalarType
     | IEnumResolver;
 }
@@ -62,22 +62,22 @@ export interface ILogger {
   log: (message: string | Error) => void;
 }
 
-export interface IConnectorCls {
-  new (context?: any): any;
+export interface IConnectorCls<TContext = any> {
+  new (context?: TContext): any;
 }
-export type IConnectorFn = (context?: any) => any;
-export type IConnector = IConnectorCls | IConnectorFn;
+export type IConnectorFn<TContext = any> = (context?: TContext) => any;
+export type IConnector<TContext = any> = IConnectorCls<TContext> | IConnectorFn<TContext>;
 
-export type IConnectors = { [key: string]: IConnector };
+export type IConnectors<TContext = any> = { [key: string]: IConnector<TContext> };
 
-export interface IExecutableSchemaDefinition {
+export interface IExecutableSchemaDefinition<TContext = any> {
   typeDefs: ITypeDefinitions;
-  resolvers?: IResolvers | Array<IResolvers>;
-  connectors?: IConnectors;
+  resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>;
+  connectors?: IConnectors<TContext>;
   logger?: ILogger;
   allowUndefinedInResolve?: boolean;
   resolverValidationOptions?: IResolverValidationOptions;
-  directiveResolvers?: IDirectiveResolvers<any, any>;
+  directiveResolvers?: IDirectiveResolvers<any, TContext>;
   parseOptions?: GraphQLParseOptions;
 }
 
@@ -88,7 +88,7 @@ export type IFieldIteratorFn = (
 ) => void;
 
 export type NextResolverFn = () => Promise<any>;
-export type DirectiveResolverFn<TSource, TContext> = (
+export type DirectiveResolverFn<TSource = any, TContext = any> = (
   next: NextResolverFn,
   source: TSource,
   args: { [argName: string]: any },
@@ -96,7 +96,7 @@ export type DirectiveResolverFn<TSource, TContext> = (
   info: GraphQLResolveInfo,
 ) => any;
 
-export interface IDirectiveResolvers<TSource, TContext> {
+export interface IDirectiveResolvers<TSource = any, TContext = any> {
   [directiveName: string]: DirectiveResolverFn<TSource, TContext>;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './interfaces';
 export * from './schemaGenerator';
 export * from './mock';
 export * from './stitching';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export * from './interfaces';
+export * from './Interfaces';
 export * from './schemaGenerator';
 export * from './mock';
 export * from './stitching';

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -111,7 +111,7 @@ function _generateSchema(
   return schema;
 }
 
-function makeExecutableSchema({
+function makeExecutableSchema<TContext = any>({
   typeDefs,
   resolvers = {},
   connectors,
@@ -120,7 +120,7 @@ function makeExecutableSchema({
   resolverValidationOptions = {},
   directiveResolvers = null,
   parseOptions = {},
-}: IExecutableSchemaDefinition) {
+}: IExecutableSchemaDefinition<TContext>) {
   const jsSchema = _generateSchema(
     typeDefs,
     resolvers,


### PR DESCRIPTION
- [X] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
  - This is a small change
- [X] Make sure all of the significant new logic is covered by tests
  - No new logic
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

This PR adds generic typings to several interfaces related to resolvers, adds an optional `TContext` type parameter to `makeExecutableSchema`, and exports the interfaces file (so that the generic-ified types can be used to give a type signature to objects manually, especially for uses of `TSource`).