### PR TITLE
Remove extra bracket from docs

### DIFF
--- a/docs/source/schema-directives.md
+++ b/docs/source/schema-directives.md
@@ -170,7 +170,7 @@ const directiveResolvers = {
   // directive resolvers implement
 };
 
-attachDirectiveResolvers(
+attachDirectiveResolvers({
   schema,
   directiveResolvers,
 });


### PR DESCRIPTION
Fixed a simple mistake in the docs on directives

```
attachDirectiveResolvers(
   schema,
   directiveResolvers,
 });
```

Should be 

```
attachDirectiveResolvers(
   schema,
   directiveResolvers,
);
```
