### PR TITLE
Handle undefined path in `getErrorsFromParent`

### DIFF
--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -11,6 +11,8 @@ if (
   ERROR_SYMBOL = '@@__subSchemaErrors';
 }
 
+export const ErrorSymbol = ERROR_SYMBOL;
+
 export function annotateWithChildrenErrors(
   object: any,
   childrenErrors: Array<{ path?: Array<string | number> }>,
@@ -62,7 +64,7 @@ export function getErrorsFromParent(
   const errors = (object && object[ERROR_SYMBOL]) || [];
   const childrenErrors: Array<{ path?: Array<string | number> }> = [];
   for (const error of errors) {
-    if (error.path.length === 1 && error.path[0] === fieldName) {
+    if ((!error.path) || (error.path.length === 1 && error.path[0] === fieldName)) {
       return {
         kind: 'OWN',
         error,

--- a/src/test/testErrors.ts
+++ b/src/test/testErrors.ts
@@ -3,7 +3,9 @@ import {
   GraphQLResolveInfo
 } from 'graphql';
 import {
-  checkResultAndHandleErrors
+  checkResultAndHandleErrors,
+  getErrorsFromParent,
+  ErrorSymbol,
 } from '../stitching/errors';
 
 import 'mocha';
@@ -17,7 +19,25 @@ class ErrorWithResult extends Error {
   }
 }
 
+const mockErrors = {
+  responseKey: '',
+  [ErrorSymbol]: [
+    {
+      message: 'Test error without path',
+    },
+  ],
+};
+
 describe('Errors', () => {
+  describe('getErrorsFromParent', () => {
+    it('should return OWN error kind if path is not defined', () => {
+      assert.deepEqual(
+        getErrorsFromParent(mockErrors, 'responseKey'),
+        { kind: 'OWN', error: mockErrors[ErrorSymbol][0] },
+      );
+    });
+  });
+
   describe('checkResultAndHandleErrors', () => {
     it('persists single error with a result', done => {
       const result = {


### PR DESCRIPTION
Added falsy check for the `error.path` value in `getErrorsFromParent`. If the path is undefined, the function will return the error with `kind: OWN` for the given field.

