### PR TITLE
Expose linkToFetcher

### DIFF
--- a/src/stitching/index.ts
+++ b/src/stitching/index.ts
@@ -2,6 +2,7 @@ import makeRemoteExecutableSchema from './makeRemoteExecutableSchema';
 import introspectSchema from './introspectSchema';
 import mergeSchemas from './mergeSchemas';
 import delegateToSchema, { createDocument } from './delegateToSchema';
+import linkToFetcher from './linkToFetcher';
 
 export {
   makeRemoteExecutableSchema,
@@ -11,4 +12,5 @@ export {
   // but exposed for the community use
   delegateToSchema,
   createDocument,
+  linkToFetcher,
 };


### PR DESCRIPTION
TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

This is super beneficial for the case where you want to resolve a query from a remote schema directly, when you have the full document.

If you want to send a batched query, and you have access to the Document and the remoteSchema, using `execute` will send N requests for N root fields. 

To get around this and send a single request, you could use the remote schemas internal link and fire

```javascript
linkToFetcher(remote._link)(operation)
```

Which is what I am currently doing. 
It works great, but I am importing `linkToFetcher` like:
```javascript
import linkToFetcher from '../../node_modules/graphql-tools/dist/stitching/linkToFetcher'
```