### PR TITLE
Remove unnecessary print and subsequent parse

### DIFF
--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -1,8 +1,10 @@
-import { GraphQLSchema } from 'graphql';
-import { introspectionQuery, buildClientSchema } from 'graphql';
+import { GraphQLSchema, DocumentNode } from 'graphql';
+import { introspectionQuery, buildClientSchema, parse } from 'graphql';
 import { ApolloLink } from 'apollo-link';
 import { Fetcher } from './makeRemoteExecutableSchema';
 import linkToFetcher from './linkToFetcher';
+
+const parsedIntrospectionQuery: DocumentNode = parse(introspectionQuery);
 
 export default async function introspectSchema(
   fetcher: ApolloLink | Fetcher,
@@ -14,7 +16,7 @@ export default async function introspectSchema(
   }
 
   const introspectionResult = await (fetcher as Fetcher)({
-    query: introspectionQuery,
+    query: parsedIntrospectionQuery,
     context: linkContext,
   });
 

--- a/src/stitching/linkToFetcher.ts
+++ b/src/stitching/linkToFetcher.ts
@@ -1,4 +1,3 @@
-import { parse } from 'graphql';
 import { Fetcher, FetcherOperation } from './makeRemoteExecutableSchema';
 
 import {
@@ -11,11 +10,6 @@ export { execute } from 'apollo-link';
 
 export default function linkToFetcher(link: ApolloLink): Fetcher {
   return (fetcherOperation: FetcherOperation) => {
-    const linkOperation = {
-      ...fetcherOperation,
-      query: parse(fetcherOperation.query),
-    };
-
-    return makePromise(execute(link, linkOperation));
+    return makePromise(execute(link, fetcherOperation));
   };
 }

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -15,12 +15,12 @@ import {
   GraphQLInt,
   GraphQLScalarType,
   ExecutionResult,
-  print,
   buildSchema,
   printSchema,
   Kind,
   ValueNode,
   GraphQLResolveInfo,
+  DocumentNode
 } from 'graphql';
 import linkToFetcher, { execute } from './linkToFetcher';
 import isEmptyObject from '../isEmptyObject';
@@ -41,7 +41,7 @@ export type ResolverFn = (
 export type Fetcher = (operation: FetcherOperation) => Promise<ExecutionResult>;
 
 export type FetcherOperation = {
-  query: string;
+  query: DocumentNode;
   operationName?: string;
   variables?: { [key: string]: any };
   context?: { [key: string]: any };
@@ -161,7 +161,7 @@ function createResolver(fetcher: Fetcher): GraphQLFieldResolver<any, any> {
       definitions: [info.operation, ...fragments],
     };
     const result = await fetcher({
-      query: print(document),
+      query: document,
       variables: info.variableValues,
       context: { graphqlContext: context },
     });

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -730,7 +730,7 @@ export async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
 // ensure fetcher support exists from the 2.0 api
 async function makeExecutableSchemaFromFetcher(schema: GraphQLSchema) {
   const fetcher: Fetcher = ({ query, operationName, variables, context }) => {
-    return graphql(schema, query, null, context, variables, operationName);
+    return graphql(schema, print(query), null, context, variables, operationName);
   };
 
   const clientSchema = await introspectSchema(fetcher);


### PR DESCRIPTION
This PR removes an unnecessary print/parse pair that is used for making remote schema fetches 😄 

Let me know if you want me to do anything different. 

TODO:
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [X] Update CHANGELOG.md with your change