### PR TITLE
[WIP] Add failing spec for merging schemas w/ unions that implement an interface

### DIFF
--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -884,6 +884,36 @@ bookingById(id: "b1") {
         });
       });
 
+      it('unions implementing an interface', async () => {
+        const mergedResult = await graphql(
+          mergedSchema,
+          `
+            query {
+              customerById(id: "c1") {
+                ... on Person {
+                  name
+                }
+                vehicle {
+                  ... on Node {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }
+          `,
+        );
+
+        expect(mergedResult).to.deep.equal({
+          data: {
+            customerById: {
+              name: 'Exampler Customer',
+              vehicle: { __typename: 'Bike', id: 'v1' },
+            },
+          },
+        });
+      });
+
       it('input objects with default', async () => {
         const mergedResult = await graphql(
           mergedSchema,

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -469,14 +469,18 @@ const bookingRootTypeDefs = `
 
   union Vehicle = Bike | Car
 
-  type Bike {
+  type Bike implements Node {
     id: ID!
     bikeType: String
   }
 
-  type Car {
+  type Car implements Node {
     id: ID!
     licensePlate: String
+  }
+
+  interface Node {
+    id: ID!
   }
 
   type Query {


### PR DESCRIPTION
Hi team!

We are working on and attempting to roll out schema stitching in production, and have found a peculiar issue with union types, which implement an interface.

I think this repro matches the error that we are experiencing with our code.

I believe that the failing spec PR'ed below should be passing, and interestingly enough, when I add the following fragment to the `vehicle` section of the query, the spec actually passes:

```
... on Bike {
  id
}
```

I'm a bit puzzled by this behavior, since it seems like we should be able to query `... on Node { id }` and have it work w/o requesting the `Bike` fragment alongside.

The reason for choosing `Node` as the interface in the example, is that we initially noticed the error in some of our React Native/Relay components which had included the `Node` fragment and its non-null `id` field.

Any help/pointers would be greatly appreciated!
