### PR TITLE
Allow the use of extend interface when merging schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### vNEXT
 
+* Allow `extend interface` definitions in merged schemas [PR #703](https://github.com/apollographql/graphql-tools/pull/703)
 * Fix timezone bug in test for @date directive [PR #686](https://github.com/apollographql/graphql-tools/pull/686)
 
 * Expose `defaultMergedResolver` from stitching [PR #685](https://github.com/apollographql/graphql-tools/pull/685)

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -241,12 +241,14 @@ function buildSchemaFromTypeDefinitions(
 // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
 const oldTypeExtensionDefinitionKind = 'TypeExtensionDefinition';
 const newExtensionDefinitionKind = 'ObjectTypeExtension';
+const interfaceExtensionDefinitionKind = 'InterfaceTypeExtension';
 
 export function extractExtensionDefinitions(ast: DocumentNode) {
   const extensionDefs = ast.definitions.filter(
     (def: DefinitionNode) =>
       def.kind === oldTypeExtensionDefinitionKind ||
-      (def.kind as any) === newExtensionDefinitionKind,
+      (def.kind as any) === newExtensionDefinitionKind ||
+      (def.kind as any) === interfaceExtensionDefinitionKind,
   );
 
   return Object.assign({}, ast, {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -177,6 +177,9 @@ const loneExtend = `
 
 let interfaceExtensionTest = `
   # No-op for older versions since this feature does not yet exist
+  extend type DownloadableProduct {
+    filesize: Int
+  }
 `;
 
 if (['^0.11', '^0.12'].indexOf(process.env.GRAPHQL_VERSION) === -1) {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -174,6 +174,16 @@ const loneExtend = `
   }
 `;
 
+const interfaceExtensionTest = `
+  extend interface Downloadable {
+    filesize: Int
+  }
+
+  extend type DownloadableProduct {
+    filesize: Int
+  }
+`;
+
 if (process.env.GRAPHQL_VERSION === '^0.11') {
   scalarTest = `
     # Description of TestScalar.
@@ -289,6 +299,7 @@ testCombinations.forEach(async combination => {
           bookingSchema,
           productSchema,
           scalarTest,
+          interfaceExtensionTest,
           enumSchema,
           linkSchema,
           loneExtend,
@@ -327,6 +338,11 @@ testCombinations.forEach(async combination => {
                 );
               },
             },
+          },
+          DownloadableProduct: {
+            filesize() {
+              return 1024;
+            }
           },
           LinkType: {
             property: {
@@ -2269,6 +2285,39 @@ fragment BookingFragment on Booking {
               },
             ],
           },
+        });
+      });
+
+      it('interface extensions', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              products {
+                id
+                __typename
+                ... on Downloadable {
+                  filesize
+                }
+              }
+            }
+          `,
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            products: [
+              {
+                id: 'pd1',
+                __typename: 'SimpleProduct',
+              },
+              {
+                id: 'pd2',
+                __typename: 'DownloadableProduct',
+                filesize: 1024
+              },
+            ]
+          }
         });
       });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Allows `mergeSchemas` to recognize `extend interface` as a valid definition to pass to graphql's `extendSchema` as logged in #699.