### PR TITLE
Move Docs Renovate configuration into top-level `renovate.json`.

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,10 +20,5 @@
     "build": "chexo apollo-hexo-config -- generate",
     "clean": "hexo clean",
     "test": "npm run clean; npm run build"
-  },
-  "renovate": {
-    "extends": [
-      "apollo-docs"
-    ]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,8 @@
 {
-  "packageFiles": ["docs/package.json"]
+  "pathRules": [
+    {
+      "paths": ["docs/package.json"],
+      "extends": ["apollo-docs"]
+    }
+  ]
 }


### PR DESCRIPTION
As determined in https://github.com/renovateapp/config-help/issues/23#issuecomment-377202632,
it seems that it's not possible to have this sort of inherited
configuration.  It's possible that when I first introduced this behavior
that this behavior was on its way out (and the breaking change in Renovate
v11 on its way in).

Luckily, Renovate's shared configuration option still allows this to be
relatively painless and our `apollo-docs` shared configuration[0] does most
of the heavy lifting here.

[0] https://github.com/apollographql/renovate-config-apollo-docs
[1] https://github.com/meteor/hexo-theme-meteor

Closes #711.