### PR TITLE
Only run Renovate on `docs/package.json`.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "packageFiles": ["docs/package.json"],
   "pathRules": [
     {
       "paths": ["docs/package.json"],


### PR DESCRIPTION
If we want to get this enabled on the rest of the `graphql-tools` dependencies, we'll just want to revert this commit, but we should be prepared for something that looks like this (which was what happened in https://github.com/apollographql/graphql-tools/pull/713 when I failed to consider that the changes in #712 would try to Renovate the whole repository:

<img src="https://user-images.githubusercontent.com/841294/38417048-84d664c8-399f-11e8-9397-b77d998c9567.png" width=350>

