### PR TITLE
Add inheritResolversFromInterfaces option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Fix typo in schema-directive.md deprecated example[PR #706](https://github.com/apollographql/graphql-tools/pull/706)
 * Fix timezone bug in test for @date directive [PR #686](https://github.com/apollographql/graphql-tools/pull/686)
 * Expose `defaultMergedResolver` from stitching [PR #685](https://github.com/apollographql/graphql-tools/pull/685)
-
 * Add `requireResolversForResolveType` to resolver validation options [PR #698](https://github.com/apollographql/graphql-tools/pull/698)
+* Add `inheritResolversFromInterfaces` to `makeExecutableSchema` and `addResolveFunctionsToSchema` [PR #720](https://github.com/apollographql/graphql-tools/pull/720)
 
 ### v2.23.0
 

--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -334,6 +334,10 @@ const jsSchema = makeExecutableSchema({
   logger, // optional
   allowUndefinedInResolve = false, // optional
   resolverValidationOptions = {}, // optional
+  directiveResolvers = null, // optional
+  schemaDirectives = null,  // optional
+  parseOptions = {},  // optional
+  inheritResolversFromInterfaces = false  // optional
 });
 ```
 
@@ -357,3 +361,5 @@ const jsSchema = makeExecutableSchema({
   - `requireResolversForResolveType` will require a `resolveType()` method for Interface and Union types. This can be passed in with the field resolvers as `__resolveType()`. False to disable the warning.
 
   - `allowResolversNotInSchema` turns off the functionality which throws errors when resolvers are found which are not present in the schema. Defaults to `false`, to help catch common errors.
+
+- `inheritResolversFromInterfaces` GraphQL Objects that implement interfaces will inherit missing resolvers from their interface types defined in the `resolvers` object.

--- a/docs/source/resolvers.md
+++ b/docs/source/resolvers.md
@@ -12,7 +12,7 @@ Keep in mind that GraphQL resolvers can return [promises](https://developer.mozi
 
 In order to respond to queries, a schema needs to have resolve functions for all fields. Resolve functions cannot be included in the GraphQL schema language, so they must be added separately. This collection of functions is called the "resolver map".
 
-The `resolverMap` object should have a map of resolvers for each relevant GraphQL Object Type. The following is an example of a valid `resolverMap` object:
+The `resolverMap` object (`IResolvers`) should have a map of resolvers for each relevant GraphQL Object Type. The following is an example of a valid `resolverMap` object:
 
 ```js
 const resolverMap = {
@@ -143,15 +143,16 @@ const resolverMap = {
 In addition to using a resolver map with `makeExecutableSchema`, you can use it with any GraphQL.js schema by importing the following function from `graphql-tools`:
 
 <h3 id="addResolveFunctionsToSchema" title="addResolveFunctionsToSchema">
-  addResolveFunctionsToSchema(schema, resolverMap)
+  addResolveFunctionsToSchema({ schema, resolvers, resolverValidationOptions?, inheritResolversFromInterfaces? })
 </h3>
 
-`addResolveFunctionsToSchema` takes two arguments, a GraphQLSchema and a resolver map, and modifies the schema in place by attaching the resolvers to the relevant types.
+`addResolveFunctionsToSchema` takes an options object of `IAddResolveFunctionsToSchemaOptions` and modifies the schema in place by attaching the resolvers to the relevant types.
+
 
 ```js
 import { addResolveFunctionsToSchema } from 'graphql-tools';
 
-const resolverMap = {
+const resolvers = {
   RootQuery: {
     author(obj, { name }, context){
       console.log("RootQuery called with context " +
@@ -161,7 +162,17 @@ const resolverMap = {
   },
 };
 
-addResolveFunctionsToSchema(schema, resolverMap);
+addResolveFunctionsToSchema({ schema, resolvers });
+```
+
+The `IAddResolveFunctionsToSchemaOptions` object has 4 properties that are described in [`makeExecutableSchema`](/docs/graphql-tools/generate-schema.html#makeExecutableSchema).
+```ts
+export interface IAddResolveFunctionsToSchemaOptions {
+  schema: GraphQLSchema;
+  resolvers: IResolvers;
+  resolverValidationOptions?: IResolverValidationOptions;
+  inheritResolversFromInterfaces?: boolean;
+}
 ```
 
 <h3 id="addSchemaLevelResolveFunction" title="addSchemaLevelResolveFunction">

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -26,6 +26,13 @@ export interface IResolverValidationOptions {
   allowResolversNotInSchema?: boolean;
 }
 
+export interface IAddResolveFunctionsToSchemaOptions {
+  schema: GraphQLSchema;
+  resolvers: IResolvers;
+  resolverValidationOptions?: IResolverValidationOptions;
+  inheritResolversFromInterfaces?: boolean;
+}
+
 export interface IResolverOptions<TSource = any, TContext = any> {
   resolve?: IFieldResolver<TSource, TContext>;
   subscribe?: IFieldResolver<TSource, TContext>;

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -85,6 +85,7 @@ export interface IExecutableSchemaDefinition<TContext = any> {
   directiveResolvers?: IDirectiveResolvers<any, TContext>;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
   parseOptions?: GraphQLParseOptions;
+  inheritResolversFromInterfaces?: boolean;
 }
 
 export type IFieldIteratorFn = (

--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -393,7 +393,7 @@ function addResolveFunctionsToSchema(
   legacyInputResolvers?: IResolvers,
   legacyInputValidationOptions?: IResolverValidationOptions) {
   if (options instanceof GraphQLSchema) {
-    console.warn('idk');
+    console.warn('addResolveFunctionsToSchema has a new api with more options see "IAddResolveFunctionsToSchemaOptions"');
     options = {
       schema: options,
       resolvers: legacyInputResolvers,


### PR DESCRIPTION
This adds `inheritResolversFromInterfaces` to `addResolveFunctionsToSchema` and `makeExecutableSchema`

Later on we'll want to support interfaces implementing other interfaces
https://github.com/facebook/graphql/issues/295

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached #616
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->