### PR TITLE
BUG - Fix failing tests when on a different timezone

### DIFF
--- a/src/test/testDirectives.ts
+++ b/src/test/testDirectives.ts
@@ -633,7 +633,7 @@ describe('@directives', () => {
         field.resolve = async function (source, { format, ...args }, context, info) {
           format = format || defaultFormat;
           const date = await resolve.call(this, source, args, context, info);
-          return formatDate(date, format);
+          return formatDate(date, format, true);
         };
       }
     }


### PR DESCRIPTION
When running this test using `Australian Eastern Standard Time (AEST), @ 17:05` test would end up failing with the following error: 

`AssertionError: expected { today: 'March 16, 2018' } to deeply equal { today: 'March 15, 2018' }`