### PR TITLE
Correct outdated statement in generate-schema.md

### DIFF
--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -354,7 +354,7 @@ const jsSchema = makeExecutableSchema({
 - `resolverValidationOptions` is an optional argument which accepts an `ResolverValidationOptions` object which has the following boolean properties:
   - `requireResolversForArgs` will cause `makeExecutableSchema` to throw an error if no resolve function is defined for a field that has arguments.
 
-  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. By default, both of these are true, which can help catch errors faster.
+  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. Setting to `true` can help catch errors faster.
 
   - `requireResolversForAllFields` asserts that *all* fields have a valid resolve function.
 

--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -354,7 +354,7 @@ const jsSchema = makeExecutableSchema({
 - `resolverValidationOptions` is an optional argument which accepts an `ResolverValidationOptions` object which has the following boolean properties:
   - `requireResolversForArgs` will cause `makeExecutableSchema` to throw an error if no resolve function is defined for a field that has arguments.
 
-  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. Setting this to `true` can be helpful in catching errors.
+  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. Setting this to `true` can be helpful in catching errors, but defaults to `false` to avoid confusing behavior for those coming from other GraphQL libraries.
 
   - `requireResolversForAllFields` asserts that *all* fields have a valid resolve function.
 

--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -354,7 +354,7 @@ const jsSchema = makeExecutableSchema({
 - `resolverValidationOptions` is an optional argument which accepts an `ResolverValidationOptions` object which has the following boolean properties:
   - `requireResolversForArgs` will cause `makeExecutableSchema` to throw an error if no resolve function is defined for a field that has arguments.
 
-  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. Setting to `true` can help catch errors faster.
+  - `requireResolversForNonScalar` will cause `makeExecutableSchema` to throw an error if a non-scalar field has no resolver defined. Setting this to `true` can be helpful in catching errors.
 
   - `requireResolversForAllFields` asserts that *all* fields have a valid resolve function.
 


### PR DESCRIPTION
This statement is [quite old](https://github.com/apollographql/graphql-tools/commit/0614197255a4fb23d28acc9d3122cac80bc5f7e8) and, at least in my usage, is incorrect. I had to explicitly set these options to `true` before they had any effect.

/label docs