### PR TITLE
Suppress warning when callling `mergeSchemas`

### DIFF
--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -246,7 +246,7 @@ export default function mergeSchemas({
     );
   });
 
-  addResolveFunctionsToSchema(mergedSchema, fullResolvers);
+  addResolveFunctionsToSchema({ schema: mergedSchema, resolvers: fullResolvers });
 
   forEachField(mergedSchema, field => {
     if (field.resolve) {


### PR DESCRIPTION
When using mergeSchema, we get this warning.

`The addResolveFunctionsToSchema function takes named options now; see IAddResolveFunctionsToSchemaOptions.`