### PR TITLE
Expose `checkResultAndHandleErrors`

### DIFF
--- a/src/stitching/index.ts
+++ b/src/stitching/index.ts
@@ -3,6 +3,7 @@ import introspectSchema from './introspectSchema';
 import mergeSchemas from './mergeSchemas';
 import delegateToSchema, { createDocument } from './delegateToSchema';
 import defaultMergedResolver from './defaultMergedResolver';
+import { checkResultAndHandleErrors } from './errors'
 
 export {
   makeRemoteExecutableSchema,
@@ -13,4 +14,5 @@ export {
   delegateToSchema,
   createDocument,
   defaultMergedResolver,
+  checkResultAndHandleErrors,
 };


### PR DESCRIPTION
Given the current implementation of sub-schema errors (using Symbol and such), i think this function needs to be exposed (for undocumented use) so people using other Apollo tooling can surface these errors. 

CC: @stubailo 
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->