### PR TITLE
Add ability to supply custom createRemoteResolver to mRES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### vNEXT
 
+* Add `createResolver` option to `makeRemoteExecutableSchema` [PR #734](https://github.com/apollographql/graphql-tools/pull/734)
+
 ### v2.24.0
 
 * Allow `extend interface` definitions in merged schemas [PR #703](https://github.com/apollographql/graphql-tools/pull/703)

--- a/docs/source/remote-schemas.md
+++ b/docs/source/remote-schemas.md
@@ -198,6 +198,17 @@ const schema = makeRemoteExecutableSchema({
 
 Given a GraphQL.js schema (can be a non-executable client schema made by `buildClientSchema`) and a [Link](#link) or [Fetcher](#fetcher), produce a GraphQL Schema that routes all requests to the link or fetcher.
 
+You can also pass a `createResolver` function to `makeRemoteExecutableSchema` to override how the fetch resolvers are created and executed. The `createResolver` param accepts a `Fetcher` as its first argument and returns a resolver function. This opens up the possibility for users to create batching mechanisms for fetches.
+```js
+const createResolver: (fetcher: Fetcher) => GraphQLFieldResolver<any, any> = // . . .
+
+const schema = makeRemoteExecutableSchema({
+  schema,
+  link,
+  createResolver
+});
+```
+
 <h3 id="introspectSchema" title="introspectSchema">
   introspectSchema(fetcher, [context])
 </h3>

--- a/src/stitching/index.ts
+++ b/src/stitching/index.ts
@@ -1,4 +1,4 @@
-import makeRemoteExecutableSchema from './makeRemoteExecutableSchema';
+import makeRemoteExecutableSchema, { createResolver as defaultCreateRemoteResolver } from './makeRemoteExecutableSchema';
 import introspectSchema from './introspectSchema';
 import mergeSchemas from './mergeSchemas';
 import delegateToSchema, { createDocument } from './delegateToSchema';
@@ -13,4 +13,5 @@ export {
   delegateToSchema,
   createDocument,
   defaultMergedResolver,
+  defaultCreateRemoteResolver
 };

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -51,10 +51,12 @@ export default function makeRemoteExecutableSchema({
   schema,
   link,
   fetcher,
+  createResolver: customCreateResolver = createResolver
 }: {
   schema: GraphQLSchema | string;
   link?: ApolloLink;
   fetcher?: Fetcher;
+  createResolver?: (fetcher: Fetcher) => GraphQLFieldResolver<any, any>
 }): GraphQLSchema {
   if (!fetcher && link) {
     fetcher = linkToFetcher(link);
@@ -74,7 +76,7 @@ export default function makeRemoteExecutableSchema({
   const queryType = schema.getQueryType();
   const queries = queryType.getFields();
   Object.keys(queries).forEach(key => {
-    queryResolvers[key] = createResolver(fetcher);
+    queryResolvers[key] = customCreateResolver(fetcher);
   });
 
   // prepare mutation resolvers
@@ -83,7 +85,7 @@ export default function makeRemoteExecutableSchema({
   if (mutationType) {
     const mutations = mutationType.getFields();
     Object.keys(mutations).forEach(key => {
-      mutationResolvers[key] = createResolver(fetcher);
+      mutationResolvers[key] = customCreateResolver(fetcher);
     });
   }
 
@@ -153,7 +155,7 @@ export default function makeRemoteExecutableSchema({
   });
 }
 
-function createResolver(fetcher: Fetcher): GraphQLFieldResolver<any, any> {
+export function createResolver(fetcher: Fetcher): GraphQLFieldResolver<any, any> {
   return async (root, args, context, info) => {
     const fragments = Object.keys(info.fragments).map(fragment => info.fragments[fragment]);
     const document = {


### PR DESCRIPTION
Allowing users to pass in this function will let users create custom fetching logic, including batching multiple queries into a single request. 

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->