### PR TITLE
add commentDescription to printSchema call to match other uses

### DIFF
--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -61,12 +61,14 @@ export default function makeRemoteExecutableSchema({
   }
 
   let typeDefs: string;
+  const printOptions = { commentDescriptions: true };
 
   if (typeof schema === 'string') {
     typeDefs = schema;
     schema = buildSchema(typeDefs);
   } else {
-    typeDefs = printSchema(schema);
+    // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
+    typeDefs = (printSchema as any)(schema, printOptions);
   }
 
   // prepare query resolvers


### PR DESCRIPTION
#541 fixed most instances of calls to graphql-js functions that as of 0.12 require special options to enable comment-based field descriptions, but missed one. This PR just adds that same option to the call to `printSchema()` in `src/stitching/makeRemoteExecutableSchema.ts`.

I had to cast it as any temporarily because `@types/graphql` hasn't been updated, but other code that did similar things left a comment reference to #542 so I did the same.