### PR TITLE
Fix error when merging schema without a query

### DIFF
--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -114,21 +114,24 @@ export default function mergeSchemas({
       }
     });
 
-    Object.keys(queryType.getFields()).forEach(name => {
-      if (!fullResolvers.Query) {
-        fullResolvers.Query = {};
-      }
-      fullResolvers.Query[name] = createDelegatingResolver(
-        mergeInfo,
-        'query',
-        name,
-      );
-    });
+    if (queryType) {
+      Object.keys(queryType.getFields()).forEach(name => {
+        if (!fullResolvers.Query) {
+          fullResolvers.Query = {};
+        }
+        fullResolvers.Query[name] = createDelegatingResolver(
+          mergeInfo,
+          'query',
+          name,
+        );
+      });
 
-    queryFields = {
-      ...queryFields,
-      ...queryType.getFields(),
-    };
+      queryFields = {
+        ...queryFields,
+        ...queryType.getFields(),
+      };
+    }
+
 
     if (mutationType) {
       if (!fullResolvers.Mutation) {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -660,6 +660,23 @@ bookingById(id: "b1") {
         expect(mergedResult).to.deep.equal(bookingResult);
       });
 
+      it('merging schema without a query', async () => {
+        const mutationOnlySchema = makeExecutableSchema({
+          typeDefs: `
+            type Mutation {
+              testMutation: Boolean
+            }
+          `,
+          resolvers: {
+            Mutation: { testMutation: () => true },
+          }
+        });
+
+        const mergedMutation = mergeSchemas({ schemas: [mergedSchema, mutationOnlySchema]});
+
+        expect(mergedMutation).to.be.an.instanceof(GraphQLSchema);
+      });
+
       it('local subscriptions working in merged schema', done => {
         const mockNotification = {
           notifications: {


### PR DESCRIPTION
This fixes a case when you try to merge a schema which has no query defined with an arbitrary one.
Issues: #639 #659 

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->