### PR TITLE
Fix transform with RenameTypes on list return, if type are renamed

### DIFF
--- a/src/test/testTransforms.ts
+++ b/src/test/testTransforms.ts
@@ -100,6 +100,10 @@ describe('transforms', () => {
                 testString
               }
             }
+            properties(limit: 1) {
+               __typename
+               id
+            }
             propertyById(id: "p1") {
               ... on Property_Property {
                 id
@@ -125,6 +129,12 @@ describe('transforms', () => {
           interfaceTest: {
             testString: 'test',
           },
+          properties: [
+            {
+              __typename: 'Property_Property',
+              id: 'p1',
+            }
+          ],
           propertyById: {
             id: 'p1',
           },

--- a/src/transforms/RenameTypes.ts
+++ b/src/transforms/RenameTypes.ts
@@ -89,7 +89,7 @@ export default class RenameTypes implements Transform {
     return result;
   }
 
-  private renameTypes(value: any, name: string) {
+  private renameTypes(value: any, name?: string) {
     if (name === '__typename') {
       return this.renamer(value);
     }
@@ -98,14 +98,24 @@ export default class RenameTypes implements Transform {
       const newObject = Object.create(Object.getPrototypeOf(value));
       let returnNewObject = false;
 
-      Object.keys(value).forEach(key => {
-        const oldChild = value[key];
-        const newChild = this.renameTypes(oldChild, key);
-        newObject[key] = newChild;
-        if (newChild !== oldChild) {
-          returnNewObject = true;
-        }
-      });
+      if (newObject instanceof Array) {
+        value.forEach((oldChild: any) => {
+          const newChild = this.renameTypes(oldChild);
+          newObject.push(newChild);
+          if (newChild !== oldChild) {
+            returnNewObject = true;
+          }
+        });
+      } else {
+        Object.keys(value).forEach(key => {
+          const oldChild = value[key];
+          const newChild = this.renameTypes(oldChild, key);
+          newObject[key] = newChild;
+          if (newChild !== oldChild) {
+            returnNewObject = true;
+          }
+        });
+      }
 
       if (returnNewObject) {
         return newObject;


### PR DESCRIPTION
Related to #755 

The problem is the function `renameTypes`, Object.keys() with assignment of the key on the array, it's not a proper way for construct an array, leading to iteration problem later.

```javascript
var items = [{id: "1"},{id: "2"}];
var newItems = Object.create(Object.getPrototypeOf(items));

Object.keys(items).forEach((key) => {
   newItems[key] = items[key];
});

console.log(newItems);
console.log('Length', newItems.length); 
// Result
Array { '0': { id: '1' }, '1': { id: '2' } }
Length 0
```

Maybe it's better to have two condition in `renameTypes`, one for object and one for array, i'm open to suggestion.

If the PR satisfied you, i'm would be really happy if we can merge it quickly, i'm really excited to used this new transform api 🙂