### PR TITLE
Test that multiple fields can be added to a single type when stitching

### DIFF
--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -148,6 +148,10 @@ let linkSchema = `
     The property of the booking.
     """
     property: Property
+    """
+    A textual description of the booking.
+    """
+    textDescription: String
   }
 
   extend type Property implements Node {
@@ -283,6 +287,8 @@ if (process.env.GRAPHQL_VERSION === '^0.11') {
     extend type Booking implements Node {
       # The property of the booking.
       property: Property
+      # A textual description of the booking.
+      textDescription: String
     }
 
     extend type Property implements Node {
@@ -395,6 +401,12 @@ testCombinations.forEach(async combination => {
                   context,
                   info,
                 });
+              },
+            },
+            textDescription: {
+              fragment: '... on Booking { id }',
+              resolve(parent, args, context, info) {
+                return `Booking #${parent.id}`;
               },
             },
           },
@@ -757,6 +769,7 @@ bookingById(id: "b1") {
                 name
                 bookings {
                   id
+                  textDescription
                   customer {
                     name
                   }
@@ -794,6 +807,7 @@ bookingById(id: "b1") {
               bookings: [
                 {
                   id: 'b4',
+                  textDescription: 'Booking #b4',
                   customer: {
                     name: 'Exampler Customer',
                   },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Hi.
We ran into some behaviour changes after updating to v3 of `graphql-tools`, where our custom resolvers were not being provided with the data that their fragments requested.
It seems that this is due to the loop within `ReplaceFieldWithFragment`'s constructor, which overwrites `this.mapping[typeName]` on each iteration, seemingly by trying to index into an array with the type name (which I presume never succeeds?) or with an empty object.
This clears out any existing fragments, leaving just the information for the "last" field for any type.