### PR TITLE
Update apollo-link to be a greater than, rather than a specific version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### Master
+
+* Loosens the apollo-link dependency [PR #765](https://github.com/apollographql/graphql-tools/pull/765)
+
 ### v3.0.0
 
 * Schema transforms and delegation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-### Master
+### vNext
 
 * Loosens the apollo-link dependency [PR #765](https://github.com/apollographql/graphql-tools/pull/765)
 * Use `getDescription` from `graphql-js` package [PR #672](https://github.com/apollographql/graphql-tools/pull/672)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
-    "apollo-link": "^1.2.1",
+    "apollo-link": "^1.2.2",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
     "iterall": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
-    "apollo-link": "1.2.1",
+    "apollo-link": "^1.2.1",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
     "iterall": "^1.1.3",


### PR DESCRIPTION
If you're using TypeScript, this ties the type definition for apollo-link to be specifically the version at 1.2.1 and if you have a less vague option in app-code then the two can not match (which is awesome, and totally the point) 

I assume that the tie to an exact version was likely a oversight, so this lets resolver potentially not just be one version. 