### PR TITLE
Fix the delegateToSchema example

### DIFF
--- a/docs/source/schema-delegation.md
+++ b/docs/source/schema-delegation.md
@@ -167,6 +167,7 @@ const resolvers = {
         operation: 'query',
         fieldName: 'bookingsByUser',
         args: {
+          limit: args.limit,
           userId: parent.id,
         },
         context,


### PR DESCRIPTION
The example states that "we want to preserve the limit argument and add an userId argument by using the User.id".
It does add the `userId` but it fails to preserve the `limit`.

**NOTE: I haven't used this feature yet, so I might be wrong.**

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->