### PR TITLE
Fragments in transformed schemas throw duplication errors

### DIFF
--- a/src/test/testFragmentsAreNotDuplicated.ts
+++ b/src/test/testFragmentsAreNotDuplicated.ts
@@ -1,0 +1,89 @@
+import {expect} from 'chai';
+import {ExecutionResult, graphql} from 'graphql';
+import {
+  addMockFunctionsToSchema,
+  makeExecutableSchema,
+  transformSchema,
+} from '..';
+
+describe('Merging schemas', () => {
+  it('should not throw `There can be only one fragment named "FieldName"` errors', async () => {
+    const originalSchema = makeExecutableSchema({
+      typeDefs: rawSchema,
+    });
+
+    addMockFunctionsToSchema({schema: originalSchema});
+
+    const originalResult = await graphql(
+      originalSchema,
+      query,
+      undefined,
+      undefined,
+      variables,
+    );
+    assertNoDuplicateFragmentErrors(originalResult);
+
+    const transformedSchema = transformSchema(originalSchema, []);
+
+    const transformedResult = await graphql(
+      transformedSchema,
+      query,
+      undefined,
+      undefined,
+      variables,
+    );
+    assertNoDuplicateFragmentErrors(transformedResult);
+  });
+});
+
+const rawSchema = `
+  type Post {
+    id: ID!
+    title: String!
+    owner: User!
+  }
+
+  type User {
+    id: ID!
+    email: String
+  }
+
+  type Query {
+    post(id: ID!): Post
+  }
+`;
+
+const query = `
+  query getPostById($id: ID!) {
+    post(id: $id) {
+      ...Post
+      owner {
+        ...PostOwner
+        email
+      }
+    }
+  }
+
+  fragment Post on Post {
+    id
+    title
+    owner {
+      ...PostOwner
+    }
+  }
+
+  fragment PostOwner on User {
+    id
+  }
+`;
+
+const variables = {
+  id: 123,
+};
+
+function assertNoDuplicateFragmentErrors(result: ExecutionResult) {
+  // Run assertion against each array element for better test failure output.
+  if (result.errors) {
+    result.errors.forEach(error => expect(error.message).to.equal(''));
+  }
+}

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -1,12 +1,13 @@
 require('source-map-support').install();
 
-import './testSchemaGenerator';
+import './testAlternateMergeSchemas';
+import './testDirectives';
+import './testErrors';
+import './testFragmentsAreNotDuplicated';
 import './testLogger';
-import './testMocking';
-import './testResolution';
 import './testMakeRemoteExecutableSchema';
 import './testMergeSchemas';
+import './testMocking';
+import './testResolution';
+import './testSchemaGenerator';
 import './testTransforms';
-import './testAlternateMergeSchemas';
-import './testErrors';
-import './testDirectives';


### PR DESCRIPTION
If a fragment is splatted multiple times into the same query body, it breaks after being run through `transformSchema`. The request works in base GraphQL and in v2 of this library, but not since attempting to upgrade to v3. If no schema transformation is used, the request processes correctly.

E.g. this query throws the error `There can be only one fragment named "PostOwner"`. 
```
query getPostById($id: ID!) {
  post(id: $id) {
    ...Post
    owner {
      ...PostOwner
      email
    }
  }
}

fragment Post on Post {
  id
  title
  owner {
    ...PostOwner
  }
}

fragment PostOwner on User {
  id
}
```
`PostOwner` is defined in the `Post` fragment, but we also want to override the `owner` field to fetch more data (the `email` as well as the `id`). Removing the `...PostOwner` in the main query works around this issue.

The reason this is coming up in our workflow is we have a fairly heavily linked graph, and we have a lot of fragments in our requests to standardise the data being brought back. Some requests need one or two extra fields & so it is convenient to simply ask for those fields inline, rather than re-writing the whole query & defining new fragments.

Attached is a failing test case as talked about with @freiksenet in Slack.