### PR TITLE
Remove lodash merge from docs

### DIFF
--- a/docs/source/generate-schema.md
+++ b/docs/source/generate-schema.md
@@ -228,18 +228,16 @@ export default makeExecutableSchema({
 });
 ```
 
-You can do the same thing with resolvers - just pass around multiple resolver objects, and at the end combine them together using something like the Lodash `merge` function:
+You can do the same thing with resolvers - just pass around multiple resolver objects, and at the end combine them together into a plain array. They will be deeply merged by makeExecutableSchema.
 
 ```js
-import { merge } from 'lodash';
-
 import { resolvers as gitHubResolvers } from './github/schema';
 import { resolvers as sqlResolvers } from './sql/schema';
 
 const rootResolvers = { ... };
 
-// Merge all of the resolver objects together
-const resolvers = merge(rootResolvers, gitHubResolvers, sqlResolvers);
+// resolvers will be merged together by makeExecutableSchema.
+const resolvers = [rootResolvers, gitHubResolvers, sqlResolvers];
 ```
 
 <h2 id="extend-types">Extending Types</h2>


### PR DESCRIPTION
The latest graphql-tools already has a merge function. Lodash merge is not needed now.