### PR TITLE
fix template string issue for visitType error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+### vNext
+* Fixed a visitType error printing the name of the variable typeName rather than its value due to a template string being incorrectly formatted. [#783] https://github.com/apollographql/graphql-tools/pull/783
+
 ### v3.0.2
 
 * Fixed duplicate fragments getting added during transform in `FilterToSchema` [#778](https://github.com/apollographql/graphql-tools/pull/778)

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -231,7 +231,7 @@ function mergeSchemasImplementation({
         type = (<TypeWithResolvers>resultType).type;
         typeResolvers = (<TypeWithResolvers>resultType).resolvers;
       } else {
-        throw new Error('Invalid `visitType` result for type "${typeName}"');
+        throw new Error(`Invalid visitType result for type ${typeName}`);
       }
       types[typeName] = recreateType(type, resolveType, false);
       if (typeResolvers) {


### PR DESCRIPTION
Fixes a visitType error printing the name of the variable `typeName` rather than its value due to a template string being incorrectly formatted. 