### PR TITLE
Add option to skip validation in delegateToSchema

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -54,6 +54,7 @@ export interface IDelegateToSchemaOptions<TContext = { [key: string]: any }> {
   context: TContext;
   info: GraphQLResolveInfo;
   transforms?: Array<Transform>;
+  skipValidation?: boolean;
 }
 
 export type MergeInfo = {

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -72,9 +72,11 @@ async function delegateToSchemaImplementation(
 
   const processedRequest = applyRequestTransforms(rawRequest, transforms);
 
-  const errors = validate(options.schema, processedRequest.document);
-  if (errors.length > 0) {
-    throw errors;
+  if (!options.skipValidation) {
+    const errors = validate(options.schema, processedRequest.document);
+    if (errors.length > 0) {
+      throw errors;
+    }
   }
 
   if (options.operation === 'query' || options.operation === 'mutation') {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Hey @stubailo @abernix, this adds a `skipValidation` flag to `delegateToSchema`, which prevents `validate` from being run which can be costly. Especially when delegating internally within a request, we typically don't need to validate again. 

I will add a test for this option, but I wanted to hear your thoughts first. 