### PR TITLE
Fix #792: syntax error as of TS 2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.
+
+### vNEXT
+
+* Fixed ECMAScript syntax error incompatible with TypeScript 2.9 [#807](https://github.com/apollographql/graphql-tools/pull/807)
+
 ### v3.0.2
 
 * Fixed duplicate fragments getting added during transform in `FilterToSchema` [#778](https://github.com/apollographql/graphql-tools/pull/778)

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -32,7 +32,7 @@ import CheckResultAndHandleErrors from '../transforms/CheckResultAndHandleErrors
 
 export default function delegateToSchema(
   options: IDelegateToSchemaOptions | GraphQLSchema,
-  ...args: any[],
+  ...args: any[]
 ): Promise<any> {
   if (options instanceof GraphQLSchema) {
     throw new Error(


### PR DESCRIPTION
Cannot have trailing comma after rest args
https://blogs.msdn.microsoft.com/typescript/2018/05/16/announcing-typescript-2-9-rc/

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.