### PR TITLE
Remove JSON type since Apollo supports it directly

### DIFF
--- a/docs/source/scalars.md
+++ b/docs/source/scalars.md
@@ -19,45 +19,6 @@ For more information about GraphQL's type system, please refer to the [official 
 
 Note that [Apollo Client does not currently have a way to automatically interpret custom scalars](https://github.com/apollostack/apollo-client/issues/585), so there's no way to automatically reverse the serialization on the client.
 
-### Using a package
-
-Here, we'll take the [graphql-type-json](https://github.com/taion/graphql-type-json) package as an example to demonstrate what can be done. This npm package defines a JSON GraphQL scalar type.
-
-Add the `graphql-type-json` package to your project's dependencies :
-
-```shell
-$ npm install --save graphql-type-json
-```
-
-In your JavaScript code, require the type defined by in the npm package and use it :
-
-```js
-import { makeExecutableSchema } from 'graphql-tools';
-import GraphQLJSON from 'graphql-type-json';
-
-const schemaString = `
-
-scalar JSON
-
-type Foo {
-  aField: JSON
-}
-
-type Query {
-  foo: Foo
-}
-
-`;
-
-const resolveFunctions = {
-  JSON: GraphQLJSON
-};
-
-const jsSchema = makeExecutableSchema({ typeDefs: schemaString, resolvers: resolveFunctions });
-```
-
-Remark : `GraphQLJSON` is a [`GraphQLScalarType`](http://graphql.org/graphql-js/type/#graphqlscalartype) instance.
-
 <h3 id="graphqlscalartype" title="GraphQLScalarType">Custom `GraphQLScalarType` instance</h3>
 
 If needed, you can define your own [GraphQLScalarType](http://graphql.org/graphql-js/type/#graphqlscalartype) instance. This can be done the following way :


### PR DESCRIPTION
This could possibly be written as an issue too and it's totally ok if this is not merged. I struggled with a new schema and Apollo server while trying to use the `graphql-type-json` library as part of my schema + resolvers. I was getting a message like this:

```
/tmp/X/node_modules/graphql-tools/dist/schemaGenerator.js:332
        Object.keys(resolvers[typeName]).forEach(function (fieldName) {
               ^

TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at /tmp/X/node_modules/graphql-tools/dist/schemaGenerator.js:332:16
    at Array.forEach (<anonymous>)
    at addResolveFunctionsToSchema (//tmp/X/node_modules/graphql-tools/dist/schemaGenerator.js:324:28)
    at _generateSchema (/tmp/X/node_modules/graphql-tools/dist/schemaGenerator.js:98:5)
    at Object.makeExecutableSchema (/tmp/X/node_modules/graphql-tools/dist/schemaGenerator.js:110:20)
    at ApolloServerBase (/tmp/X/node_modules/apollo-server-core/dist/ApolloServer.js:87:31)
    at new ApolloServer (/tmp/X/node_modules/apollo-server/dist/index.js:58:42)
    at Object.<anonymous> (/tmp/X/index.js:125:16)
    at Module._compile (module.js:643:30)
```

All because I set the resolver for `JSON` to `GraphQLJSON` from `graphql-type-json`, following these docs. As I found out, `JSON` is a built in with Apollo Server 2 (beta)! 🎉 

It would be fantastic if:

* There was a banner in this section mentioning that `JSON` is a built in Scalar type for Apollo Server
* The error message from `graphql-tools` could detect issues like this (even literally this one) and provide a better error message (and how to resolve it)

cc @peggyrayzis 