### PR TITLE
Add inheritResolversFromInterfaces option - mergeSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNEXT
+
+* Add `inheritResolversFromInterfaces` option to `mergeSchemas` [PR #812](https://github.com/apollographql/graphql-tools/pull/812)
+
 ### v3.0.5
 
 * Update apollo-link to 1.2.2 [#785](https://github.com/apollographql/graphql-tools/pull/785)
@@ -17,7 +21,6 @@
   defined in the parent query.
   [Issue #753](https://github.com/apollographql/graphql-tools/issues/753)
   [PR #806](https://github.com/apollographql/graphql-tools/pull/806)
-
 
 ### v3.0.2
 

--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -305,6 +305,7 @@ mergeSchemas({
       };
     },
   ) => GraphQLNamedType;
+  inheritResolversFromInterfaces?: boolean;
 })
 ```
 
@@ -406,3 +407,7 @@ const onTypeConflict = (left, right, info) => {
 ```
 
 When using schema transforms, `onTypeConflict` is often unnecessary, since transforms can be used to prevent conflicts before merging schemas. However, if you're not using schema transforms, `onTypeConflict` can be a quick way to make `mergeSchemas` produce more desirable results.
+
+#### inheritResolversFromInterfaces
+
+The `inheritResolversFromInterfaces` option is simply passed through to `addResolveFunctionsToSchema`, which is called when adding resolvers to the schema under the covers. See [`addResolveFunctionsToSchema`](/docs/graphql-tools/resolvers.md#addResolveFunctionsToSchema) for more info.

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -61,12 +61,14 @@ export default function mergeSchemas({
   schemas,
   onTypeConflict,
   resolvers,
-  schemaDirectives
+  schemaDirectives,
+  inheritResolversFromInterfaces
 }: {
   schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
   onTypeConflict?: OnTypeConflict;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
+  inheritResolversFromInterfaces?: boolean;
 }): GraphQLSchema {
   let visitType: VisitType = defaultVisitType;
   if (onTypeConflict) {
@@ -75,19 +77,21 @@ export default function mergeSchemas({
     );
     visitType = createVisitTypeFromOnTypeConflict(onTypeConflict);
   }
-  return mergeSchemasImplementation({ schemas, visitType, resolvers, schemaDirectives });
+  return mergeSchemasImplementation({ schemas, visitType, resolvers, schemaDirectives, inheritResolversFromInterfaces });
 }
 
 function mergeSchemasImplementation({
   schemas,
   visitType,
   resolvers,
-  schemaDirectives
+  schemaDirectives,
+  inheritResolversFromInterfaces
 }: {
   schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
   visitType?: VisitType;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
+  inheritResolversFromInterfaces?: boolean;
 }): GraphQLSchema {
   const allSchemas: Array<GraphQLSchema> = [];
   const typeCandidates: { [name: string]: Array<MergeTypeCandidate> } = {};
@@ -283,6 +287,7 @@ function mergeSchemasImplementation({
   addResolveFunctionsToSchema({
     schema: mergedSchema,
     resolvers: mergeDeep(generatedResolvers, resolvers),
+    inheritResolversFromInterfaces
   });
 
   forEachField(mergedSchema, field => {


### PR DESCRIPTION
This simply adds support for `inheritResolversFromInterfaces` via `mergeSchemas` (a simple passthrough thanks to the wonderful work done in pull request #720).

I didn't open an issue first since it was a pretty small change and I was looking for a quick way to achieve my goal, but I did link issue #616 below since this is just extending the concept to an additional util.

Let me know if this isn't in line with the original intent of that issue and/or the vision of the project, but I think it will prove to be a useful option.


TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes) issue #616 
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->