### PR TITLE
Use casual for mocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add support for overlapping fragments in ReplaceFieldWithFragment. [#894](https://github.com/apollographql/graphql-tools/issues/894)
 * `delegateToSchema` now behaves like `info.mergeInfo.delegateToSchema` for fragment handling [Issue #876](https://github.com/apollographql/graphql-tools/issues/876) [PR #885](https://github.com/apollographql/graphql-tools/pull/885)
 * Make schema transforms work with subscriptions, make it so that subscription errors don't disappear when using mergeSchemas [#793](https://github.com/apollographql/graphql-tools/issues/793) [#780](https://github.com/apollographql/graphql-tools/issues/780)
+* Updates mocking to use [`casual`](https://www.npmjs.com/package/casual) [PR #817](https://github.com/apollographql/graphql-tools/pull/817)
 
 ### v3.0.5
 

--- a/docs/source/mocking.md
+++ b/docs/source/mocking.md
@@ -214,6 +214,9 @@ const schema = buildClientSchema(introspectionResult);
 addMockFunctionsToSchema({schema});
 ```
 
+## Seeding
+`graphql-tools` uses [`casual`](https://www.npmjs.com/package/casual) to generate random integers, floats, booleans, and ids. You can seed the `casual` generator by passing `seed: <your seed value>` to `addMockFunctionsToSchema`.
+
 ## API
 
 ### addMockFunctionsToSchema
@@ -225,10 +228,11 @@ addMockFunctionsToSchema({
   schema,
   mocks: {},
   preserveResolvers: false,
+  seed?: number
 });
 ```
 
-Given an instance of GraphQLSchema and a mock object, `addMockFunctionsToSchema` modifies the schema in place to return mock data for any valid query that is sent to the server. If `mocks` is not passed, the defaults will be used for each of the scalar types. If `preserveResolvers` is set to `true`, existing resolve functions will not be overwritten to provide mock data. This can be used to mock some parts of the server and not others.
+Given an instance of GraphQLSchema and a mock object, `addMockFunctionsToSchema` modifies the schema in place to return mock data for any valid query that is sent to the server. If `mocks` is not passed, the defaults will be used for each of the scalar types. If `preserveResolvers` is set to `true`, existing resolve functions will not be overwritten to provide mock data. This can be used to mock some parts of the server and not others. The `seed` option is used to initialize the generator in order to get consistent random values between runs.
 
 ### MockList
 
@@ -239,5 +243,3 @@ new MockList(length: number | number[], mockFunction: Function);
 ```
 
 This is an object you can return from your mock resolvers which calls the `mockFunction` once for each list item. The first argument can either be an exact length, or an inclusive range of possible lengths for the list, in case you want to see how your UI responds to varying lists of data.
-
-

--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
   "dependencies": {
     "apollo-link": "^1.2.2",
     "apollo-utilities": "^1.0.1",
+    "casual": "^1.5.19",
     "deprecated-decorator": "^0.1.6",
-    "iterall": "^1.1.3",
-    "uuid": "^3.1.0"
+    "iterall": "^1.1.3"
   },
   "peerDependencies": {
     "graphql": "^0.13.0"

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -159,6 +159,7 @@ export interface IMockOptions {
   schema: GraphQLSchema;
   mocks?: IMocks;
   preserveResolvers?: boolean;
+  seed?: number
 }
 
 export interface IMockServer {

--- a/src/test/testMocking.ts
+++ b/src/test/testMocking.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { graphql, GraphQLResolveInfo } from 'graphql';
+import * as casual from 'casual';
 import { addMockFunctionsToSchema, MockList, mockServer } from '../mock';
 import {
   buildSchemaFromTypeDefinitions,
@@ -153,6 +154,7 @@ describe('Mock', () => {
       Bird: () => ({ returnInt: () => 54321 }),
       Bee: () => ({ returnInt: () => 54321 }),
     };
+    casual.seed(1);
     return mockServer(shorthand, mockMap)
       .query(testQuery)
       .then((res: any) => {
@@ -264,6 +266,7 @@ describe('Mock', () => {
       schema: jsSchema,
       mocks: {},
       preserveResolvers: true,
+      seed: 0
     });
     const testQuery = `{
       returnBirdsAndBees {
@@ -279,7 +282,7 @@ describe('Mock', () => {
     }`;
     return graphql(jsSchema, testQuery).then(res => {
       // the resolveType has been called twice
-      expect(spy).to.equal(2);
+      expect(spy).to.equal(5);
     });
   });
 
@@ -675,12 +678,12 @@ describe('Mock', () => {
   it('can mock a list of ints', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Int: () => 123 };
-    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap });
+    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap, seed: 0 });
     const testQuery = `{
       returnListOfInt
     }`;
     const expected = {
-      returnListOfInt: [123, 123],
+      returnListOfInt: Array(5).fill(123) ,
     };
     return graphql(jsSchema, testQuery).then(res => {
       expect(res.data).to.deep.equal(expected);
@@ -693,21 +696,16 @@ describe('Mock', () => {
       String: () => 'a',
       Int: () => 1,
     };
-    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap });
+    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap, seed: 5 });
     const testQuery = `{
       returnListOfListOfObject { returnInt, returnString }
     }`;
+    const obj = { returnInt: 1, returnString: 'a' };
     const expected = {
       returnListOfListOfObject: [
-        [
-          { returnInt: 1, returnString: 'a' },
-          { returnInt: 1, returnString: 'a' },
-        ],
-        [
-          { returnInt: 1, returnString: 'a' },
-          { returnInt: 1, returnString: 'a' },
-        ],
-      ],
+        Array(1).fill(obj),
+        Array(9).fill(obj)
+      ]
     };
     return graphql(jsSchema, testQuery).then(res => {
       expect(res.data).to.deep.equal(expected);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
Adds `casual` for mocking, and fixes the `TODO` for adding a seed random array length. 

I wanted to get initial feedback before updating docs. Should I add `seed` to `mockServer` as well? 

**TODO**:
- [x]  Rebase on #816 
- [x] Update docs with seeding

cc: @benjamn 

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

/label enhancement
To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->