### PR TITLE
Rename `resolveType` to `__resolveType` in missing interface type resolver warning

### DIFF
--- a/src/schemaGenerator.ts
+++ b/src/schemaGenerator.ts
@@ -532,7 +532,7 @@ function checkForResolveTypeResolver(schema: GraphQLSchema, requireResolversForR
         throw new SchemaError(`Type "${type.name}" is missing a "resolveType" resolver`);
       }
       // tslint:disable-next-line:max-line-length
-      console.warn(`Type "${type.name}" is missing a "resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.`);
+      console.warn(`Type "${type.name}" is missing a "__resolveType" resolver. Pass false into "resolverValidationOptions.requireResolversForResolveType" to disable this warning.`);
     }
   });
 }


### PR DESCRIPTION
This small change was suggested by @evans on https://github.com/apollographql/apollo-server/issues/1075#issuecomment-393230841

Hopefully, this should help removing confusion for less experimented GraphQL users.

Do you think we should update [the error message](https://github.com/apollographql/graphql-tools/blob/master/src/schemaGenerator.ts#L532) as well?