### PR TITLE
Fixes #839 - Improve cryptic error message when resolver value is inv…

### DIFF
--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -1308,6 +1308,32 @@ describe('generating schema from shorthand', () => {
     ).to.not.throw();
   });
 
+  it('throws if resolver value is invalid', () => {
+    const short = `
+      type Person {
+        name: String
+        age: Int
+      }
+      type RootQuery {
+        search(name: String): [Person]
+      }
+      schema {
+        query: RootQuery
+      }
+    `;
+
+    const rf = {
+      Searchable: undefined
+    } as any;
+
+    expect(() =>
+      makeExecutableSchema({ typeDefs: short, resolvers: rf }),
+    ).to.throw(
+      `"Searchable" defined in resolvers, but has invalid value "undefined". A resolver's value ` +
+      `must be of type object or function.`
+    );
+  });
+
   it('doesnt let you define resolver field not present in schema', () => {
     const short = `
       type Person {


### PR DESCRIPTION
…alid.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Fixes #839 