### PR TITLE
Add null to return type of directive visitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNEXT
+
+* Add null to return type of directive visitors.
+
 ### v3.0.4
 
 * Make sure `dist/generate` isn't excluded when published.

--- a/src/schemaVisitor.ts
+++ b/src/schemaVisitor.ts
@@ -85,25 +85,25 @@ export abstract class SchemaVisitor {
 
   /* tslint:disable:no-empty */
   public visitSchema(schema: GraphQLSchema): void {}
-  public visitScalar(scalar: GraphQLScalarType): GraphQLScalarType | void {}
-  public visitObject(object: GraphQLObjectType): GraphQLObjectType | void {}
+  public visitScalar(scalar: GraphQLScalarType): GraphQLScalarType | void | null {}
+  public visitObject(object: GraphQLObjectType): GraphQLObjectType | void | null {}
   public visitFieldDefinition(field: GraphQLField<any, any>, details: {
     objectType: GraphQLObjectType | GraphQLInterfaceType,
-  }): GraphQLField<any, any> | void {}
+  }): GraphQLField<any, any> | void | null {}
   public visitArgumentDefinition(argument: GraphQLArgument, details: {
     field: GraphQLField<any, any>,
     objectType: GraphQLObjectType | GraphQLInterfaceType,
-  }): GraphQLArgument | void {}
-  public visitInterface(iface: GraphQLInterfaceType): GraphQLInterfaceType | void {}
-  public visitUnion(union: GraphQLUnionType): GraphQLUnionType | void {}
-  public visitEnum(type: GraphQLEnumType): GraphQLEnumType | void {}
+  }): GraphQLArgument | void | null {}
+  public visitInterface(iface: GraphQLInterfaceType): GraphQLInterfaceType | void | null {}
+  public visitUnion(union: GraphQLUnionType): GraphQLUnionType | void | null {}
+  public visitEnum(type: GraphQLEnumType): GraphQLEnumType | void | null {}
   public visitEnumValue(value: GraphQLEnumValue, details: {
     enumType: GraphQLEnumType,
-  }): GraphQLEnumValue | void {}
-  public visitInputObject(object: GraphQLInputObjectType): GraphQLInputObjectType | void {}
+  }): GraphQLEnumValue | void | null {}
+  public visitInputObject(object: GraphQLInputObjectType): GraphQLInputObjectType | void | null {}
   public visitInputFieldDefinition(field: GraphQLInputField, details: {
     objectType: GraphQLInputObjectType,
-  }): GraphQLInputField | void {}
+  }): GraphQLInputField | void | null {}
   /* tslint:enable:no-empty */
 }
 


### PR DESCRIPTION
Returning null from a visitor will remove the type from the schema; however, the visitor methods were all typed without allowing `null`.
