### PR TITLE
Fix example usage of RenameRootFields transform

### DIFF
--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -218,7 +218,7 @@ const transformedChirpSchema = transformSchema(chirpSchema, [
     (operation: string, rootField: string) => rootField !== 'chirpsByAuthorId'
   ),
   new RenameTypes((name: string) => `Chirp_${name}`),
-  new RenameRootFields((name: string) => `Chirp_${name}`),
+  new RenameRootFields((operation: 'Query' | 'Mutation' | 'Subscription', name: string) => `Chirp_${name}`),
 ]);
 ```
 


### PR DESCRIPTION
In addition to the field's name, the transform function is also given the type of operation as the first argument.

None of the below TODO items seem application to documentation updates, so just leaving them there.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->