### PR TITLE
Fix IResolvers type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Loosens the apollo-link dependency [PR #765](https://github.com/apollographql/graphql-tools/pull/765)
 * Use `getDescription` from `graphql-js` package [PR #672](https://github.com/apollographql/graphql-tools/pull/672)
+* Fix `IResolvers` type for correct Union & Interface resolver support. [#896](https://github.com/apollographql/graphql-tools/pull/896)
 
 ### v3.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Loosens the apollo-link dependency [PR #765](https://github.com/apollographql/graphql-tools/pull/765)
 * Use `getDescription` from `graphql-js` package [PR #672](https://github.com/apollographql/graphql-tools/pull/672)
-* Fix `IResolvers` type for correct Union & Interface resolver support. [#896](https://github.com/apollographql/graphql-tools/pull/896)
+* Update `IResolvers` to use source & context generics and to support all resolver use cases. [#896](https://github.com/apollographql/graphql-tools/pull/896)
 
 ### v3.0.5
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -79,13 +79,14 @@ export type IFieldResolver<TSource, TContext> = (
 export type ITypedef = (() => ITypedef[]) | string | DocumentNode;
 export type ITypeDefinitions = ITypedef | ITypedef[];
 export type IResolverObject<TSource = any, TContext = any> = {
-  [key: string]: IFieldResolver<TSource, TContext> | IResolverOptions;
+  [key: string]: IFieldResolver<TSource, TContext>;
 };
 export type IEnumResolver = { [key: string]: string | number };
 export interface IResolvers<TSource = any, TContext = any> {
   [key: string]:
     | (() => any)
     | IResolverObject<TSource, TContext>
+    | IResolverOptions<TSource, TContext>
     | GraphQLScalarType
     | IEnumResolver;
 }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -79,7 +79,10 @@ export type IFieldResolver<TSource, TContext> = (
 export type ITypedef = (() => ITypedef[]) | string | DocumentNode;
 export type ITypeDefinitions = ITypedef | ITypedef[];
 export type IResolverObject<TSource = any, TContext = any> = {
-  [key: string]: IFieldResolver<TSource, TContext> | IResolverOptions<TSource, TContext>;
+  [key: string]:
+    | IFieldResolver<TSource, TContext>
+    | IResolverOptions<TSource, TContext>
+    | IResolverObject<TSource, TContext>;
 };
 export type IEnumResolver = { [key: string]: string | number };
 export interface IResolvers<TSource = any, TContext = any> {

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -79,7 +79,7 @@ export type IFieldResolver<TSource, TContext> = (
 export type ITypedef = (() => ITypedef[]) | string | DocumentNode;
 export type ITypeDefinitions = ITypedef | ITypedef[];
 export type IResolverObject<TSource = any, TContext = any> = {
-  [key: string]: IFieldResolver<TSource, TContext>;
+  [key: string]: IFieldResolver<TSource, TContext> | IResolverOptions<TSource, TContext>;
 };
 export type IEnumResolver = { [key: string]: string | number };
 export interface IResolvers<TSource = any, TContext = any> {


### PR DESCRIPTION
- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

- [x] blocking

I believe that the `IResolvers` type is incorrect as  according to the resolvers documentation it should provide support for the example under [Unions and interfaces](https://www.apollographql.com/docs/graphql-tools/resolvers.html#Unions-and-interfaces).

```ts
const resolverMap = {
    Vehicle: {
        __resolveType: (obj, context, info) => "Object",
    },
};

```

In addition, whilst not mentioned in the documentation, I believe the below should also be allowed, so I added the possibility of `IResolverObject` having itself as a property:

```ts
const resolverMap = {
    Query: {
        Vehicle: {
            resolve: () => true,
            __resolveType: (obj, context, info) => "Object",
        },
    },
};
```

 I also added the source & context generics whilst doing this.