### PR TITLE
mergeSchema keeps ENUM description and deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `IResolvers` to use source & context generics and to support all resolver use cases. [#896](https://github.com/apollographql/graphql-tools/pull/896)
 * `WrapQuery`'s `wrapper` param can now return a SelectionSet. [PR #902](https://github.com/apollographql/graphql-tools/pull/902) [Issue #901](https://github.com/apollographql/graphql-tools/issues/901)
 * Add null to return type of directive visitors in the TypeScript definition.
+* Make sure mergeSchemas keeps Enum descriptions and deprecation status. [PR 898](https://github.com/apollographql/graphql-tools/pull/898/)
 
 ### v3.0.5
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -87,7 +87,11 @@ export function recreateType(
     const values = type.getValues();
     const newValues = {};
     values.forEach(value => {
-      newValues[value.name] = { value: value.name };
+      newValues[value.name] = {
+        value: value.name,
+        deprecationReason: value.deprecationReason,
+        description: value.description,
+      };
     });
     return new GraphQLEnumType({
       name: type.name,

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -88,7 +88,7 @@ let enumTest = `
     """
     A test description
     """
-    TEST
+    TEST @deprecated(reason: "This is deprecated")
   }
 
   schema {
@@ -235,7 +235,7 @@ if (process.env.GRAPHQL_VERSION === '^0.11') {
     # A type that uses an Enum with a numeric constant.
     enum NumericEnum {
     # A test description
-      TEST
+      TEST @deprecated(reason: "This is deprecated")
     }
 
     schema {
@@ -614,7 +614,15 @@ testCombinations.forEach(async combination => {
             query {
               color
               numericEnum
-              __type(name: "Color") {
+              numericEnumInfo: __type(name: "NumericEnum") {
+                enumValues(includeDeprecated: true) {
+                  name
+                  description
+                  isDeprecated
+                  deprecationReason
+                }
+              }
+              colorEnumInfo: __type(name: "Color") {
                 enumValues {
                   name
                   description
@@ -630,7 +638,15 @@ testCombinations.forEach(async combination => {
             query {
               color
               numericEnum
-              __type(name: "Color") {
+              numericEnumInfo: __type(name: "NumericEnum") {
+                enumValues(includeDeprecated: true) {
+                  name
+                  description
+                  isDeprecated
+                  deprecationReason
+                }
+              }
+              colorEnumInfo: __type(name: "Color") {
                 enumValues {
                   name
                   description
@@ -644,13 +660,23 @@ testCombinations.forEach(async combination => {
           data: {
             color: 'RED',
             numericEnum: 'TEST',
-            "__type": {
-            enumValues: [
-              {
-                description: "A vivid color",
-                name: "RED"
-              }
-            ]
+            numericEnumInfo: {
+              enumValues: [
+                {
+                  description: 'A test description',
+                  name: 'TEST',
+                  isDeprecated: true,
+                  deprecationReason: 'This is deprecated',
+                },
+              ],
+            },
+            colorEnumInfo: {
+              enumValues: [
+                {
+                  description: 'A vivid color',
+                  name: 'RED',
+                },
+              ],
             },
           },
         });

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -630,11 +630,11 @@ testCombinations.forEach(async combination => {
             query {
               color
               numericEnum
-            }
-            __type(name: "Color") {
-              enumValues {
-                name
-                description
+              __type(name: "Color") {
+                enumValues {
+                  name
+                  description
+                }
               }
             }
           `,
@@ -644,6 +644,14 @@ testCombinations.forEach(async combination => {
           data: {
             color: 'RED',
             numericEnum: 'TEST',
+            "__type": {
+            enumValues: [
+              {
+                description: "A vivid color",
+                name: "RED"
+              }
+            ]
+            },
           },
         });
         expect(mergedResult).to.deep.equal(enumResult);

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -75,6 +75,9 @@ let enumTest = `
   A type that uses an Enum.
   """
   enum Color {
+    """
+    A vivid color
+    """
     RED
   }
 
@@ -82,6 +85,9 @@ let enumTest = `
   A type that uses an Enum with a numeric constant.
   """
   enum NumericEnum {
+    """
+    A test description
+    """
     TEST
   }
 
@@ -222,11 +228,13 @@ if (process.env.GRAPHQL_VERSION === '^0.11') {
   enumTest = `
     # A type that uses an Enum.
     enum Color {
+      # A vivid color
       RED
     }
 
     # A type that uses an Enum with a numeric constant.
     enum NumericEnum {
+    # A test description
       TEST
     }
 
@@ -606,6 +614,12 @@ testCombinations.forEach(async combination => {
             query {
               color
               numericEnum
+              __type(name: "Color") {
+                enumValues {
+                  name
+                  description
+                }
+              }
             }
           `,
         );
@@ -616,6 +630,12 @@ testCombinations.forEach(async combination => {
             query {
               color
               numericEnum
+            }
+            __type(name: "Color") {
+              enumValues {
+                name
+                description
+              }
             }
           `,
         );


### PR DESCRIPTION
`mergeSchemas` doesn't transpose enum description, this PR in a first time adds a failing test