### PR TITLE
Fix wrong parameter in enum example.

### DIFF
--- a/docs/source/scalars.md
+++ b/docs/source/scalars.md
@@ -255,7 +255,7 @@ const resolvers = {
   Query: {
     favoriteColor: () => 'RED',
     avatar: (root, args) => {
-      // args.favoriteColor is 'RED', 'GREEN', or 'BLUE'
+      // args.borderColor is 'RED', 'GREEN', or 'BLUE'
     },
   }
 };


### PR DESCRIPTION
Hi, just a fix in the doc. 

The parameter in query is `borderColor` and not `favoriteColor`. (or did I miss something? :/)

Thanks for you work!
Matt'

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->