### PR TITLE
Extended allowResolverNotInSchema to apply to enums as it does to other types

### DIFF
--- a/src/generate/addResolveFunctionsToSchema.ts
+++ b/src/generate/addResolveFunctionsToSchema.ts
@@ -77,6 +77,9 @@ function addResolveFunctionsToSchema(
 
       if (type instanceof GraphQLEnumType) {
         if (!type.getValue(fieldName)) {
+          if (allowResolversNotInSchema) {
+            return;
+          }
           throw new SchemaError(
             `${typeName}.${fieldName} was defined in resolvers, but enum is not in schema`,
           );

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -1343,7 +1343,7 @@ describe('generating schema from shorthand', () => {
     ).to.not.throw();
   });
 
-  it('doesnt let you define resolver field for enums not present in schema', () => {
+  it('does not let you define resolver field for enum values not present in schema', () => {
     const short = `
       enum Color {
         RED

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -1343,6 +1343,51 @@ describe('generating schema from shorthand', () => {
     ).to.not.throw();
   });
 
+  it('doesnt let you define resolver field for enums not present in schema', () => {
+    const short = `
+      enum Color {
+        RED
+      }
+
+      enum NumericEnum {
+        TEST
+      }
+
+      schema {
+        query: Query
+      }
+
+      type Query {
+        color: Color
+        numericEnum: NumericEnum
+      }
+    `;
+
+    const rf = {
+      Color: {
+        RED: '#EA3232',
+        NO_RESOLVER: '#EA3232',
+      },
+      NumericEnum: {
+        TEST: 1,
+      },
+    };
+
+    expect(() =>
+      makeExecutableSchema({ typeDefs: short, resolvers: rf }),
+    ).to.throw(`Color.NO_RESOLVER was defined in resolvers, but enum is not in schema`);
+
+    expect(() =>
+      makeExecutableSchema({
+        typeDefs: short,
+        resolvers: rf,
+        resolverValidationOptions: {
+          allowResolversNotInSchema: true,
+        },
+      }),
+    ).to.not.throw();
+  });
+
   it('throws if conflicting validation options are passed', () => {
     const typeDefs = `
     type Bird {


### PR DESCRIPTION
Essentially, I expected enums to behave in the same way as other fields when providing `allowResolverNotInSchema`. Plausible use cases for this would be the same as for any other extra resolver: planned but not yet actual implementation, a spread that includes extra fields, directives and other mechanisms for manipulating the schema after it is built, and I'm sure other reasons I haven't thought of.

It's possible this is an intentional difference having to do with enum fields themselves and being more protective of the name lookups, but I think this change makes the behavior more predictable.

Test cases document the new functionality.