### PR TITLE
Change from Authentication to Authorization header

### DIFF
--- a/docs/source/remote-schemas.md
+++ b/docs/source/remote-schemas.md
@@ -77,7 +77,7 @@ const http = new HttpLink({ uri: 'http://api.githunt.com/graphql', fetch });
 
 const link = setContext((request, previousContext) => ({
   headers: {
-    'Authentication': `Bearer ${previousContext.graphqlContext.authKey}`,
+    'Authorization': `Bearer ${previousContext.graphqlContext.authKey}`,
   }
 })).concat(http);
 
@@ -192,7 +192,7 @@ const fetcher = async ({ query, variables, operationName, context }) => {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Authentication': `Bearer ${context.authKey}`,
+      'Authorization': `Bearer ${context.authKey}`,
     },
     body: JSON.stringify({ query, variables, operationName })
   });


### PR DESCRIPTION
Looks like the docs incorrectly referenced the Authorization as "Authentication".  This updates the docs.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->