### PR TITLE
Pass and Check for Error Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Re-use errors with they contain an extensions property to make compatible with Apollo Server and it's built-in errors. [PR #925](https://github.com/apollographql/graphql-tools/pull/925)
 
 ### v3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* Re-use errors with they contain an extensions property to make compatible with Apollo Server and it's built-in errors. [PR #925](https://github.com/apollographql/graphql-tools/pull/925)
+* Re-use errors with an extensions property to make compatible with Apollo Server and it's built-in errors. [PR #925](https://github.com/apollographql/graphql-tools/pull/925)
 
 ### v3.1.1
 

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -119,5 +119,5 @@ function concatErrors(errors: Error[]) {
 }
 
 function hasResult(error: any) {
-  return error.result || (error.originalError && error.originalError.result);
+  return error.result || error.extensions || (error.originalError && error.originalError.result);
 }

--- a/src/test/testErrors.ts
+++ b/src/test/testErrors.ts
@@ -12,6 +12,14 @@ class ErrorWithResult extends Error {
   }
 }
 
+class ErrorWithExtensions extends Error {
+  public extensions: any;
+  constructor(message: string, code: string) {
+    super(message);
+    this.extensions = { code };
+  }
+}
+
 describe('Errors', () => {
   describe('getErrorsFromParent', () => {
     it('should return OWN error kind if path is not defined', () => {
@@ -44,6 +52,19 @@ describe('Errors', () => {
       }
     });
 
+    it('persists single error with extensions', () => {
+      const result = {
+        errors: [new ErrorWithExtensions('Test error', 'UNAUTHENTICATED')]
+      };
+      try {
+        checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');
+      } catch (e) {
+        assert.equal(e.message, 'Test error');
+        assert.equal(e.extensions && e.extensions.code, 'UNAUTHENTICATED');
+        assert.isUndefined(e.originalError.errors);
+      }
+    });
+
     it('persists original errors without a result', () => {
       const result = {
         errors: [new Error('Test error')]
@@ -61,7 +82,7 @@ describe('Errors', () => {
       }
     });
 
-    it('combines errors and perists the original errors', () => {
+    it('combines errors and persists the original errors', () => {
       const result = {
         errors: [new Error('Error1'), new Error('Error2')]
       };


### PR DESCRIPTION
I was working with Apollo Server 2.0 and I couldn't get my `AuthenticationError` code of `'UNAUTHENTICATED'` to get passed back to the user. https://www.apollographql.com/docs/apollo-server/v2/features/errors.html#Codes

I pin-pointed to here in `graphql-tools` and it looks like it was originally setup to use `result`, but not `extensions`?

Anyway, I copied the test for `result` and added the logic to make it work for `extensions`.


TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

