### PR TITLE
Remove Object Spreading for Transformed Subscription Results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Remove object spreading on subscription resolution [PR #928](https://github.com/apollographql/graphql-tools/pull/928)
 
 ### v3.1.1
 

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -126,9 +126,7 @@ async function delegateToSchemaImplementation(
       // for some reason the returned transformedResult needs to be nested inside the root subscription field
       // does not work otherwise...
       return {
-        [subscriptionKey]: {
-          ...transformedResult
-        },
+        [subscriptionKey]: transformedResult,
       };
     });
   }


### PR DESCRIPTION
Object spreading causes nothing to be returned when using subscriptions, removing object spreading allows subscriptions to successfully pass their resolutions.