### PR TITLE
[feature] mergeSchemas accepts DocumentNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* `mergeSchemas` now accepts `DocumentNode` elements [PR #929](https://github.com/apollographql/graphql-tools/pull/929)
 
 ### v3.1.1
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "express": "^4.16.2",
     "graphql": "^0.13.0",
     "graphql-subscriptions": "^0.5.7",
+    "graphql-tag": "^2.9.2",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -60,7 +60,7 @@ export default function mergeSchemas({
   schemaDirectives,
   inheritResolversFromInterfaces
 }: {
-  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
+  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType> | DocumentNode>;
   onTypeConflict?: OnTypeConflict;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
@@ -75,7 +75,7 @@ function mergeSchemasImplementation({
   schemaDirectives,
   inheritResolversFromInterfaces
 }: {
-  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
+  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType> | DocumentNode>;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
   inheritResolversFromInterfaces?: boolean;
@@ -137,8 +137,8 @@ function mergeSchemasImplementation({
           });
         }
       });
-    } else if (typeof schema === 'string') {
-      let parsedSchemaDocument = parse(schema);
+    } else if (typeof schema === 'string' || schema.hasOwnProperty('kind')) {
+      let parsedSchemaDocument = typeof schema === 'string' ? parse(schema) : schema as DocumentNode;
       parsedSchemaDocument.definitions.forEach(def => {
         const type = typeFromAST(def);
         if (type) {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -25,6 +25,7 @@ import {
 import { forAwaitEach } from 'iterall';
 import { makeExecutableSchema } from '../makeExecutableSchema';
 import { IResolvers } from '../Interfaces';
+import gql from 'graphql-tag';
 
 const testCombinations = [
   {
@@ -125,7 +126,7 @@ if (process.env.GRAPHQL_VERSION !== '^0.11') {
   });
 }
 
-let linkSchema = `
+let linkSchema = gql`
   """
   A new type linking the Property type.
   """


### PR DESCRIPTION
Closes #784 

Many editors provide syntax highlighting and formatting when using `graphql-tag`. This PR allows `mergeSchemas` to accept DocumentNodes in addition to strings.
<img width="257" alt="screen shot 2018-08-15 at 11 36 51 am" src="https://user-images.githubusercontent.com/5205440/44166157-86f08300-a07f-11e8-8648-31833e437c08.png">



TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->