### PR TITLE
Fix preserveResolvers behavior to apply only to default mocks

### DIFF
--- a/src/test/testMocking.ts
+++ b/src/test/testMocking.ts
@@ -751,6 +751,71 @@ describe('Mock', () => {
     });
   });
 
+  it('preserveResolvers still enables mocks to override resolvers', () => {
+    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    const mockMap = {
+      Bird: () => ({ returnString: () => 'mock me' }),
+    };
+    const resolvers = {
+      RootQuery: {
+        returnObject: () => ({
+          returnString: () => 'real talk',
+          id: () => 'id',
+        }),
+      },
+    };
+    addResolveFunctionsToSchema(jsSchema, resolvers);
+    addMockFunctionsToSchema({
+      schema: jsSchema,
+      mocks: mockMap,
+      preserveResolvers: true,
+    });
+    const testQuery = `{
+      returnObject {
+        id
+        returnString
+      }
+    }`;
+    const expected = {
+      returnObject: { id: 'id', returnString: 'mock me' },
+    };
+    return graphql(jsSchema, testQuery).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
+  });
+
+  it('preserveResolvers:false overrides all resolvers with mocks', () => {
+    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    const mockMap = {
+      Bird: () => ({ returnString: () => 'mock me' }),
+    };
+    const resolvers = {
+      RootQuery: {
+        returnObject: () => ({
+          returnString: () => 'real talk',
+          id: () => 'id',
+        }),
+      },
+    };
+    addResolveFunctionsToSchema(jsSchema, resolvers);
+    addMockFunctionsToSchema({
+      schema: jsSchema,
+      mocks: mockMap,
+    });
+    const testQuery = `{
+      returnObject {
+        id
+        returnString
+      }
+    }`;
+    const expected = {
+      returnObject: { id: 'Hello World', returnString: 'mock me' },
+    };
+    return graphql(jsSchema, testQuery).then(res => {
+      expect(res.data).to.deep.equal(expected);
+    });
+  });
+
   it('lets you mock non-leaf types conveniently', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {


### PR DESCRIPTION
The current behavior of preserveResolvers is to keep all resolvers
around even if a mock is specified to override it. This should not be
the case. Instead, if a mock is specified it should run and
preserveResolvers should prevent the default mocks from overriding the
existing resolvers

The first commit adds a breaking test. If someone is interested in fixing the issue, [src/mock.ts](https://github.com/apollographql/graphql-tools/blob/fix-preserveResolver/src/mock.ts) is the best place to start. The change will most likely involve conditionally returning a default mock for existing resolvers based on `preserveResolvers`.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->