### PR TITLE
Update field resolver interface to allow typed args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Update IFieldResolver to allow typed input args [PR #932](https://github.com/apollographql/graphql-tools/pull/932). Related to [Issue #704](https://github.com/apollographql/graphql-tools/issues/704)
 
 ### v3.1.1
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -77,9 +77,9 @@ export type MergeInfo = {
   }>;
 };
 
-export type IFieldResolver<TSource, TContext> = (
+export type IFieldResolver<TSource, TContext, TArgs = { [argument: string]: any }> = (
   source: TSource,
-  args: { [argument: string]: any },
+  args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo & { mergeInfo: MergeInfo },
 ) => any;


### PR DESCRIPTION
Related to https://github.com/apollographql/graphql-tools/issues/704

This change allows me to specify a type for the `args` object of a resolver. Without this change I cannot specify types for the `args` object of a resolver. As an example

```typescript
const resolvers = {
  Query: {
    hello: (_parent: object, args: { id: string }) => `Hello ${args.id}!`,
  },
};
```

☝️ Does not compile.

```
[ts]
Argument of type '{ typeDefs: DocumentNode; resolvers: { Query: { hello: (_parent: object, args: { id: string; }) => string; }; }; }' is not assignable to parameter of type 'Config'.
  Types of property 'resolvers' are incompatible.
    Type '{ Query: { hello: (_parent: object, args: { id: string; }) => string; }; }' is not assignable to type 'IResolvers<any, any>'.
      Property 'Query' is incompatible with index signature.
        Type '{ hello: (_parent: object, args: { id: string; }) => string; }' is not assignable to type '(() => any) | GraphQLScalarType | IEnumResolver | IResolverObject<any, any> | IResolverOptions<any, any>'.
          Type '{ hello: (_parent: object, args: { id: string; }) => string; }' has no properties in common with type 'IResolverOptions<any, any>'.
(property) typeDefs: DocumentNode
```

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->