### PR TITLE
Adjust Fetcher interface in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNEXT
 
-* ...
+* Properly document the `FetcherOperation` to accept a `DocumentNode` [PR #933](https://github.com/apollographql/graphql-tools/pull/933) [Issue #891](https://github.com/apollographql/graphql-tools/issues/891)
 
 ### v3.1.1
 

--- a/docs/source/remote-schemas.md
+++ b/docs/source/remote-schemas.md
@@ -104,7 +104,7 @@ You can also use a fetcher (like apollo-fetch or node-fetch) instead of a link. 
 type Fetcher = (operation: Operation) => Promise<ExecutionResult>;
 
 type Operation {
-  query: string;
+  query: DocumentNode;
   operationName?: string;
   variables?: Object;
   context?: Object;
@@ -161,8 +161,10 @@ Basic usage
 
 ```js
 import fetch from 'node-fetch';
+import { print } from 'graphql':
 
-const fetcher = async ({ query, variables, operationName, context }) => {
+const fetcher = async ({ query: queryDocument, variables, operationName, context }) => {
+  const query = print(queryDocument);
   const fetchResult = await fetch('http://api.githunt.com/graphql', {
     method: 'POST',
     headers: {
@@ -186,8 +188,10 @@ Authentication headers from context
 
 ```js
 import fetch from 'node-fetch';
+import { print } from 'graphql':
 
-const fetcher = async ({ query, variables, operationName, context }) => {
+const fetcher = async ({ query: queryDocument, variables, operationName, context }) => {
+  const query = print(queryDocument);
   const fetchResult = await fetch('http://api.githunt.com/graphql', {
     method: 'POST',
     headers: {


### PR DESCRIPTION
As mentioned in https://github.com/apollographql/graphql-tools/issues/891, the docs for a custom fetcher are off since a couple of months.

After https://github.com/apollographql/graphql-tools/commit/c91e5779feb3b09de2dc1efb1c5c6a82993b534c landed, the types were changed to accept a `DocumentNode` instead of a `string`.

TODO:

- [x] ~If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)~
- [x] ~Make sure all of the significant new logic is covered by tests~
- [x] Rebase your changes on master so that they can be merged easily
- [x] ~Make sure all tests and linter rules pass~
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->