### PR TITLE
Fix template strings usage in guessSchemaByRootField error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change log
 
-### vNEXT
+### 4.0.0
 
-* ...
+* Fix template strings usage in guessSchemaByRootField error message.  <br/>
+  [@nagelflorian](https://github.com/nagelflorian) in [#936](https://github.com/apollographql/graphql-tools/pull/936)
 
 ### v3.1.1
 

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -351,7 +351,7 @@ function guessSchemaByRootField(
     }
   }
   throw new Error(
-    `Could not find subschema with field \`{operation}.{fieldName}\``,
+    `Could not find subschema with field \`${operation}.${fieldName}\``,
   );
 }
 


### PR DESCRIPTION
> "Error: Could not find subschema with field `{operation}.{fieldName}`"

Hi there 👋, I just came across this error message while trying to debug some remote schema stitching issue. I guess a changelog entry and extra test coverage is not needed for this one or what do you think?