### PR TITLE
Use faker for mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
+    "@types/faker": "^4.1.3",
     "apollo-link": "^1.2.2",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
-    "iterall": "^1.1.3",
-    "uuid": "^3.1.0"
+    "faker": "^4.1.0",
+    "iterall": "^1.1.3"
   },
   "peerDependencies": {
     "graphql": "^0.13.0"

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -167,6 +167,7 @@ export interface IMockOptions {
   schema: GraphQLSchema;
   mocks?: IMocks;
   preserveResolvers?: boolean;
+  seed?: number
 }
 
 export interface IMockServer {

--- a/src/test/testMocking.ts
+++ b/src/test/testMocking.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { graphql, GraphQLResolveInfo } from 'graphql';
+import * as faker from 'faker';
 import { addMockFunctionsToSchema, MockList, mockServer } from '../mock';
 import {
   buildSchemaFromTypeDefinitions,
@@ -153,6 +154,7 @@ describe('Mock', () => {
       Bird: () => ({ returnInt: () => 54321 }),
       Bee: () => ({ returnInt: () => 54321 }),
     };
+    faker.seed(1);
     return mockServer(shorthand, mockMap)
       .query(testQuery)
       .then((res: any) => {
@@ -279,7 +281,7 @@ describe('Mock', () => {
     }`;
     return graphql(jsSchema, testQuery).then(res => {
       // the resolveType has been called twice
-      expect(spy).to.equal(2);
+      expect(spy).to.equal(9);
     });
   });
 
@@ -675,12 +677,12 @@ describe('Mock', () => {
   it('can mock a list of ints', () => {
     const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Int: () => 123 };
-    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap });
+    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap, seed: 0 });
     const testQuery = `{
       returnListOfInt
     }`;
     const expected = {
-      returnListOfInt: [123, 123],
+      returnListOfInt: Array(6).fill(123) ,
     };
     return graphql(jsSchema, testQuery).then(res => {
       expect(res.data).to.deep.equal(expected);
@@ -693,21 +695,16 @@ describe('Mock', () => {
       String: () => 'a',
       Int: () => 1,
     };
-    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap });
+    addMockFunctionsToSchema({ schema: jsSchema, mocks: mockMap, seed: 5 });
     const testQuery = `{
       returnListOfListOfObject { returnInt, returnString }
     }`;
+    const obj = { returnInt: 1, returnString: 'a' };
     const expected = {
       returnListOfListOfObject: [
-        [
-          { returnInt: 1, returnString: 'a' },
-          { returnInt: 1, returnString: 'a' },
-        ],
-        [
-          { returnInt: 1, returnString: 'a' },
-          { returnInt: 1, returnString: 'a' },
-        ],
-      ],
+        Array(0),
+        Array(9).fill(obj)
+      ]
     };
     return graphql(jsSchema, testQuery).then(res => {
       expect(res.data).to.deep.equal(expected);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

@hwillson here is mocking implemented with `faker` instead of casual. I didn't include the docs update yet  because I wanted to make sure you wanted to go this route before committing. Let me know and I will update them 🙂 