### PR TITLE
Extract the new enum and union type extensions supported by graphql-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### vNEXT
+
+* Changes to `extractExtensionDefinitions` to support `graphql-js` union and enum extensions.  <br/>
+  [@jansuchy](https://github.com/jansuchy) in [#951](https://github.com/apollographql/graphql-tools/pull/951)
+
 ### 4.0.0
 
 * Fix template strings usage in guessSchemaByRootField error message.  <br/>

--- a/src/generate/extractExtensionDefinitions.ts
+++ b/src/generate/extractExtensionDefinitions.ts
@@ -3,13 +3,17 @@ import { DocumentNode, DefinitionNode } from 'graphql';
 const newExtensionDefinitionKind = 'ObjectTypeExtension';
 const interfaceExtensionDefinitionKind = 'InterfaceTypeExtension';
 const inputObjectExtensionDefinitionKind = 'InputObjectTypeExtension';
+const unionExtensionDefinitionKind = 'UnionTypeExtension';
+const enumExtensionDefinitionKind = 'EnumTypeExtension';
 
 export default function extractExtensionDefinitions(ast: DocumentNode) {
   const extensionDefs = ast.definitions.filter(
     (def: DefinitionNode) =>
       (def.kind as any) === newExtensionDefinitionKind ||
       (def.kind as any) === interfaceExtensionDefinitionKind ||
-      (def.kind as any) === inputObjectExtensionDefinitionKind,
+      (def.kind as any) === inputObjectExtensionDefinitionKind ||
+      (def.kind as any) === unionExtensionDefinitionKind ||
+      (def.kind as any) === enumExtensionDefinitionKind,
   );
 
   return Object.assign({}, ast, {

--- a/src/test/testExtensionExtraction.ts
+++ b/src/test/testExtensionExtraction.ts
@@ -21,5 +21,47 @@ describe('Extension extraction', () => {
     expect(extensionAst.definitions).to.have.length(1);
     expect(extensionAst.definitions[0].kind).to.equal('InputObjectTypeExtension');
   });
+
+  it('extracts extended unions', () => {
+    const typeDefs = `
+      type Person {
+        name: String!
+      }
+      type Location {
+        name: String!
+      }
+      union Searchable = Person | Location
+
+      type Post {
+        name: String!
+      }
+      extend union Searchable = Post
+    `;
+
+    const astDocument = parse(typeDefs);
+    const extensionAst = extractExtensionDefinitons(astDocument);
+
+    expect(extensionAst.definitions).to.have.length(1);
+    expect(extensionAst.definitions[0].kind).to.equal('UnionTypeExtension');
+  });
+
+  it('extracts extended enums', () => {
+    const typeDefs = `
+      enum Color {
+        RED
+        GREEN
+      }
+
+      extend enum Color {
+        BLUE
+      }
+    `;
+
+    const astDocument = parse(typeDefs);
+    const extensionAst = extractExtensionDefinitons(astDocument);
+
+    expect(extensionAst.definitions).to.have.length(1);
+    expect(extensionAst.definitions[0].kind).to.equal('EnumTypeExtension');
+  });
 });
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Similarly to  #948, this makes `extractExtensionDefinitions` understand the new `union` and `enum` type extensions

Please note that this PR does not make the `enum` and `union` schema extensions "just work" with
`makeExecutableSchema` and others, because these -- same as the `input` type extension added in #948 -- actually need graphql-js v14. But at least these definitions are not skipped and we get a good descriptive message what's wrong:

```
     Error: The UnionTypeExtension kind is not yet supported by extendSchema().
```
