### PR TITLE
Update to `graphql-js` 14.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
 
 install:
   - npm config set spin=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ script:
 sudo: false
 
 env:
-  - GRAPHQL_VERSION='^0.13'
+  - GRAPHQL_VERSION='^14.0'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
 {
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
-  "editor.rulers": [110],
+  "editor.rulers": [80],
   "editor.wordWrapColumn": 110,
   "prettier.semi": true,
   "files.trimTrailingWhitespace": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### vNEXT
 
 * Support `graphql@^14.0`  <br />
-  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/graphql-tools/pull/)
+  [@hwillson](https://github.com/hwillson) in [#953](https://github.com/apollographql/graphql-tools/pull/953)
 
 ### v3.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.0
 
-* Support `graphql@^14.0`  <br />
+* Support `graphql` and `@types/graphql` 14.x.  <br />
   [@hwillson](https://github.com/hwillson) in [#953](https://github.com/apollographql/graphql-tools/pull/953)
 * Fix template strings usage in guessSchemaByRootField error message.  <br/>
   [@nagelflorian](https://github.com/nagelflorian) in [#936](https://github.com/apollographql/graphql-tools/pull/936)
@@ -11,7 +11,7 @@
 * Changes to `extractExtensionDefinitions` to properly support `graphql-js` input extensions.  <br/>
   [@jure](https://github.com/jure) in [#948](https://github.com/apollographql/graphql-tools/pull/948)
 * Stop automatically shallow cloning (via object spread syntax) transformed subscription results. Transformed subscription results are not always objects, which means object spreading can lead to invalid results.  <br/>
-  [@ericlewis](https://github.com/ericlewis) in [#928](https://github.com/apollographql/graphql-tools/pull/928)  
+  [@ericlewis](https://github.com/ericlewis) in [#928](https://github.com/apollographql/graphql-tools/pull/928)
 * Re-use errors with an `extensions` property to make compatible with Apollo Server and it's built-in errors.  <br/>
   [@edorsey](https://github.com/edorsey) in [#925](https://github.com/apollographql/graphql-tools/pull/925)
 * Documentation updates.  <br/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### vNEXT
 
-* ...
+* Support `graphql@^14.0`  <br />
+  [@hwillson](https://github.com/hwillson) in [#](https://github.com/apollographql/graphql-tools/pull/)
 
 ### v3.1.1
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "homepage": "https://github.com/apollostack/graphql-tools#readme",
   "dependencies": {
-    "apollo-link": "^1.2.2",
+    "apollo-link": "^1.2.3",
     "apollo-utilities": "^1.0.1",
     "deprecated-decorator": "^0.1.6",
     "iterall": "^1.1.3",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@types/chai": "4.0.10",
     "@types/dateformat": "^1.0.1",
-    "@types/graphql": "0.12.5",
+    "@types/graphql": "14.0.0",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",
     "@types/uuid": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "dateformat": "^3.0.3",
     "express": "^4.16.2",
     "graphql": "^14.0.2",
-    "graphql-subscriptions": "^0.5.7",
+    "graphql-subscriptions": "^1.0.0",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",
     "mocha": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint": "tslint src/**/*.ts",
     "watch": "tsc -w",
     "testonly": "mocha --reporter spec --full-trace ./dist/test/tests.js",
+    "testonly:watch": "mocha -w --reporter spec --full-trace ./dist/test/tests.js",
     "coverage": "istanbul cover _mocha -- --reporter dot --full-trace ./dist/test/tests.js",
     "postcoverage": "remap-istanbul --input coverage/coverage.json --type lcovonly --output coverage/lcov.info",
     "prepublishOnly": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "rimraf": "^2.6.2",
     "source-map-support": "^0.5.0",
     "tslint": "^5.8.0",
-    "typescript": "2.6.2"
+    "typescript": "3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "uuid": "^3.1.0"
   },
   "peerDependencies": {
-    "graphql": "^0.13.0"
+    "graphql": "^0.13.0 || ^14.0.0"
   },
   "devDependencies": {
     "@types/chai": "4.0.10",
-    "@types/graphql": "0.12.5",
     "@types/dateformat": "^1.0.1",
+    "@types/graphql": "0.12.5",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",
     "@types/uuid": "^3.4.3",
@@ -69,7 +69,7 @@
     "chai": "^4.1.2",
     "dateformat": "^3.0.3",
     "express": "^4.16.2",
-    "graphql": "^0.13.0",
+    "graphql": "^14.0.2",
     "graphql-subscriptions": "^0.5.7",
     "graphql-type-json": "^0.1.4",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-tools",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "Useful tools to create and manipulate GraphQL schemas.",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/generate/addResolveFunctionsToSchema.ts
+++ b/src/generate/addResolveFunctionsToSchema.ts
@@ -54,7 +54,7 @@ function addResolveFunctionsToSchema(
 
   // Used to map the external value of an enum to its internal value, when
   // that internal value is provided by a resolver.
-  const enumValueMap = {};
+  const enumValueMap = Object.create(null);
 
   Object.keys(resolvers).forEach(typeName => {
     const resolverValue = resolvers[typeName];

--- a/src/generate/addResolveFunctionsToSchema.ts
+++ b/src/generate/addResolveFunctionsToSchema.ts
@@ -16,8 +16,9 @@ import {
   IResolverValidationOptions,
   IAddResolveFunctionsToSchemaOptions,
 } from '../Interfaces';
-
+import { applySchemaTransforms } from '../transforms/transforms';
 import { checkForResolveTypeResolver, extendResolversFromInterfaces } from '.';
+import ConvertEnumValues from '../transforms/ConvertEnumValues';
 
 function addResolveFunctionsToSchema(
   options: IAddResolveFunctionsToSchemaOptions | GraphQLSchema,
@@ -51,6 +52,10 @@ function addResolveFunctionsToSchema(
     ? extendResolversFromInterfaces(schema, inputResolvers)
     : inputResolvers;
 
+  // Used to map the external value of an enum to its internal value, when
+  // that internal value is provided by a resolver.
+  const enumValueMap = {};
+
   Object.keys(resolvers).forEach(typeName => {
     const resolverValue = resolvers[typeName];
     const resolverType = typeof resolverValue;
@@ -63,6 +68,7 @@ function addResolveFunctionsToSchema(
     }
 
     const type = schema.getType(typeName);
+
     if (!type && typeName !== '__schema') {
       if (allowResolversNotInSchema) {
         return;
@@ -95,7 +101,18 @@ function addResolveFunctionsToSchema(
           );
         }
 
-        type.getValue(fieldName)['value'] = resolverValue[fieldName];
+        // We've encountered an enum resolver that is being used to provide an
+        // internal enum value.
+        // Reference: https://www.apollographql.com/docs/graphql-tools/scalars.html#internal-values
+        //
+        // We're storing a map of the current enums external facing value to
+        // its resolver provided internal value. This map is used to transform
+        // the current schema to a new schema that includes enums with the new
+        // internal value.
+        enumValueMap[type.name] = {
+          [fieldName]: resolverValue[fieldName],
+        };
+
         return;
       }
 
@@ -137,6 +154,16 @@ function addResolveFunctionsToSchema(
   });
 
   checkForResolveTypeResolver(schema, requireResolversForResolveType);
+
+  // If there are any enum resolver functions (that are used to return
+  // internal enum values), create a new schema that includes enums with the
+  // new internal facing values.
+  const updatedSchema = applySchemaTransforms(
+    schema,
+    [new ConvertEnumValues(enumValueMap)],
+  );
+
+  return updatedSchema;
 }
 
 function getFieldsForType(type: GraphQLType): GraphQLFieldMap<any, any> {

--- a/src/makeExecutableSchema.ts
+++ b/src/makeExecutableSchema.ts
@@ -49,9 +49,9 @@ export function makeExecutableSchema<TContext = any>({
 
   // Arguments are now validated and cleaned up
 
-  const schema = buildSchemaFromTypeDefinitions(typeDefs, parseOptions);
+  let schema = buildSchemaFromTypeDefinitions(typeDefs, parseOptions);
 
-  addResolveFunctionsToSchema({
+  schema = addResolveFunctionsToSchema({
     schema,
     resolvers: resolverMap,
     resolverValidationOptions,

--- a/src/mock.ts
+++ b/src/mock.ts
@@ -13,6 +13,7 @@ import {
   getNamedType,
   GraphQLNamedType,
   GraphQLFieldResolver,
+  GraphQLNonNull,
 } from 'graphql';
 import * as uuid from 'uuid';
 import {
@@ -140,7 +141,10 @@ function addMockFunctionsToSchema({
         return result;
       }
 
-      if (fieldType instanceof GraphQLList) {
+      if (
+        fieldType instanceof GraphQLList ||
+        fieldType instanceof GraphQLNonNull
+      ) {
         return [
           mockType(fieldType.ofType)(root, args, context, info),
           mockType(fieldType.ofType)(root, args, context, info),
@@ -297,7 +301,7 @@ function isObject(thing: any) {
 }
 
 // returns a random element from that ary
-function getRandomElement(ary: any[]) {
+function getRandomElement(ary: ReadonlyArray<any>) {
   const sample = Math.floor(Math.random() * ary.length);
   return ary[sample];
 }

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -135,9 +135,9 @@ async function delegateToSchemaImplementation(
 function createDocument(
   targetField: string,
   targetOperation: Operation,
-  originalSelections: Array<SelectionNode>,
+  originalSelections: ReadonlyArray<SelectionNode>,
   fragments: Array<FragmentDefinitionNode>,
-  variables: Array<VariableDefinitionNode>,
+  variables: ReadonlyArray<VariableDefinitionNode>,
   operationName: NameNode,
 ): DocumentNode {
   let selections: Array<SelectionNode> = [];

--- a/src/stitching/errors.ts
+++ b/src/stitching/errors.ts
@@ -1,4 +1,10 @@
-import { GraphQLResolveInfo, responsePathAsArray, ExecutionResult, GraphQLFormattedError } from 'graphql';
+import {
+  GraphQLResolveInfo,
+  responsePathAsArray,
+  ExecutionResult,
+  GraphQLFormattedError,
+  GraphQLError,
+} from 'graphql';
 import { locatedError } from 'graphql/error';
 import { getResponseKeyFromInfo } from './getResponseKeyFromInfo';
 
@@ -12,7 +18,7 @@ if (
   ERROR_SYMBOL = '@@__subSchemaErrors';
 }
 
-export function annotateWithChildrenErrors(object: any, childrenErrors: Array<GraphQLFormattedError>): any {
+export function annotateWithChildrenErrors(object: any, childrenErrors: ReadonlyArray<GraphQLFormattedError>): any {
   if (!childrenErrors || childrenErrors.length === 0) {
     // Nothing to see here, move along
     return object;
@@ -79,8 +85,8 @@ export function getErrorsFromParent(
 }
 
 class CombinedError extends Error {
-  public errors: Error[];
-  constructor(message: string, errors: Error[]) {
+  public errors: ReadonlyArray<GraphQLError>;
+  constructor(message: string, errors: ReadonlyArray<GraphQLError>) {
     super(message);
     this.errors = errors;
   }
@@ -103,18 +109,17 @@ export function checkResultAndHandleErrors(
       result.errors.length === 1 && hasResult(result.errors[0])
         ? result.errors[0]
         : new CombinedError(concatErrors(result.errors), result.errors);
-
     throw locatedError(newError, info.fieldNodes, responsePathAsArray(info.path));
   }
 
   let resultObject = result.data[responseKey];
   if (result.errors) {
-    resultObject = annotateWithChildrenErrors(resultObject, result.errors as Array<GraphQLFormattedError>);
+    resultObject = annotateWithChildrenErrors(resultObject, result.errors as ReadonlyArray<GraphQLFormattedError>);
   }
   return resultObject;
 }
 
-function concatErrors(errors: Error[]) {
+function concatErrors(errors: ReadonlyArray<GraphQLError>) {
   return errors.map(error => error.message).join('\n');
 }
 

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -248,7 +248,7 @@ function mergeSchemasImplementation({
     });
   });
 
-  addResolveFunctionsToSchema({
+  mergedSchema = addResolveFunctionsToSchema({
     schema: mergedSchema,
     resolvers: mergeDeep(generatedResolvers, resolvers),
     inheritResolversFromInterfaces

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -88,9 +88,10 @@ export function recreateType(
     const newValues = {};
     values.forEach(value => {
       newValues[value.name] = {
-        value: value.name,
+        value: value.value,
         deprecationReason: value.deprecationReason,
         description: value.description,
+        astNode: value.astNode,
       };
     });
     return new GraphQLEnumType({

--- a/src/stitching/typeFromAST.ts
+++ b/src/stitching/typeFromAST.ts
@@ -139,7 +139,7 @@ function makeInputObjectType(
   });
 }
 
-function makeFields(nodes: Array<FieldDefinitionNode>) {
+function makeFields(nodes: ReadonlyArray<FieldDefinitionNode>) {
   const result = {};
   nodes.forEach(node => {
     result[node.name.value] = {
@@ -151,7 +151,7 @@ function makeFields(nodes: Array<FieldDefinitionNode>) {
   return result;
 }
 
-function makeValues(nodes: Array<InputValueDefinitionNode>) {
+function makeValues(nodes: ReadonlyArray<InputValueDefinitionNode>) {
   const result = {};
   nodes.forEach(node => {
     const type = resolveType(node.type, 'input') as GraphQLInputType;

--- a/src/test/testDirectives.ts
+++ b/src/test/testDirectives.ts
@@ -860,7 +860,7 @@ describe('@directives', () => {
           },
 
           parseLiteral(ast: StringValueNode) {
-            return type.parseLiteral(ast);
+            return type.parseLiteral(ast, {});
           }
         });
       }

--- a/src/test/testDirectives.ts
+++ b/src/test/testDirectives.ts
@@ -28,7 +28,6 @@ import {
   GraphQLList,
   GraphQLUnionType,
   GraphQLInt,
-  visit,
 } from 'graphql';
 
 import formatDate = require('dateformat');

--- a/src/test/testDirectives.ts
+++ b/src/test/testDirectives.ts
@@ -28,13 +28,28 @@ import {
   GraphQLList,
   GraphQLUnionType,
   GraphQLInt,
+  visit,
 } from 'graphql';
 
 import formatDate = require('dateformat');
 
 const typeDefs = `
 directive @schemaDirective(role: String) on SCHEMA
+directive @queryTypeDirective on OBJECT
+directive @queryFieldDirective on FIELD_DEFINITION
+directive @enumTypeDirective on ENUM
 directive @enumValueDirective on ENUM_VALUE
+directive @dateDirective(tz: String) on SCALAR
+directive @interfaceDirective on INTERFACE
+directive @interfaceFieldDirective on FIELD_DEFINITION
+directive @inputTypeDirective on INPUT_OBJECT
+directive @inputFieldDirective on INPUT_FIELD_DEFINITION
+directive @mutationTypeDirective on OBJECT
+directive @mutationArgumentDirective on ARGUMENT_DEFINITION
+directive @mutationMethodDirective on FIELD_DEFINITION
+directive @objectTypeDirective on OBJECT
+directive @objectFieldDirective on FIELD_DEFINITION
+directive @unionDirective on UNION
 
 schema @schemaDirective(role: "admin") {
   query: Query
@@ -376,86 +391,7 @@ describe('@directives', () => {
     );
   });
 
-  it('can handle all kinds of undeclared arguments', () => {
-    const schemaText = `
-    enum SpineEnum {
-      VERTEBRATE @directive(spineless: false)
-      INVERTEBRATE @directive(spineless: true)
-    }
-
-    type Query @directive(c: null, d: 1, e: { oyez: 3.1415926 }) {
-      animal(
-        name: String @directive(f: ["n", "a", "m", "e"])
-      ): Animal @directive(g: INVERTEBRATE)
-    }
-
-    type Animal {
-      name: String @directive(default: "horse")
-      spine: SpineEnum @directive(default: VERTEBRATE)
-    }
-    `;
-
-    let enumValueCount = 0;
-    let objectCount = 0;
-    let argumentCount = 0;
-    let fieldCount = 0;
-
-    const schemaDirectives = {
-      directive: class extends SchemaDirectiveVisitor {
-        public visitEnumValue(value: GraphQLEnumValue) {
-          ++enumValueCount;
-          assert.strictEqual(
-            this.args.spineless,
-            value.name === 'INVERTEBRATE'
-          );
-        }
-
-        public visitObject(object: GraphQLObjectType) {
-          ++objectCount;
-          assert.strictEqual(this.args.c, null);
-          assert.strictEqual(this.args.d, 1);
-          assert.strictEqual(Math.round(this.args.e.oyez), 3);
-        }
-
-        public visitArgumentDefinition(arg: GraphQLArgument) {
-          ++argumentCount;
-          assert.strictEqual(this.args.f.join(''), 'name');
-        }
-
-        public visitFieldDefinition(field: GraphQLField<any, any>, details: {
-          objectType: GraphQLObjectType,
-        }) {
-          ++fieldCount;
-          switch (details.objectType.name) {
-          case 'Query':
-            assert.strictEqual(this.args.g, 'INVERTEBRATE');
-            break;
-          case 'Animal':
-            if (field.name === 'name') {
-              assert.strictEqual(this.args.default, 'horse');
-            } else if (field.name === 'spine') {
-              assert.strictEqual(this.args.default, 'VERTEBRATE');
-            }
-            break;
-          default:
-            throw new Error('unexpected field parent object type');
-          }
-        }
-      }
-    };
-
-    makeExecutableSchema({
-      typeDefs: schemaText,
-      schemaDirectives,
-    });
-
-    assert.strictEqual(enumValueCount, 2);
-    assert.strictEqual(objectCount, 1);
-    assert.strictEqual(argumentCount, 1);
-    assert.strictEqual(fieldCount, 3);
-  });
-
-  it('can also handle declared arguments', () => {
+  it('can handle declared arguments', () => {
     const schemaText = `
     directive @oyez(
       times: Int = 5,
@@ -1026,6 +962,8 @@ describe('@directives', () => {
   it('can be used to implement the @uniqueID example', () => {
     const schema = makeExecutableSchema({
       typeDefs: `
+      directive @uniqueID(name: String, from: [String]) on OBJECT
+
       type Query {
         people: [Person]
         locations: [Location]
@@ -1158,6 +1096,8 @@ describe('@directives', () => {
   it('can remove enum values', () => {
     const schema = makeExecutableSchema({
       typeDefs: `
+      directive @remove(if: Boolean) on ENUM_VALUE
+
       type Query {
         age(unit: AgeUnit): Int
       }
@@ -1189,6 +1129,8 @@ describe('@directives', () => {
   it('can swap names of GraphQLNamedType objects', () => {
     const schema = makeExecutableSchema({
       typeDefs: `
+      directive @rename(to: String) on OBJECT
+
       type Query {
         people: [Person]
       }
@@ -1238,7 +1180,7 @@ describe('@directives', () => {
     const visited = new Set<GraphQLObjectType>();
     const schema = makeExecutableSchema({
       typeDefs: `
-      directive @hasScope(scope: [String]) on QUERY | FIELD
+      directive @hasScope(scope: [String]) on QUERY | FIELD | OBJECT
 
       type Query @hasScope {
         oyez: String

--- a/src/test/testErrors.ts
+++ b/src/test/testErrors.ts
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
-import { GraphQLResolveInfo } from 'graphql';
+import { GraphQLResolveInfo, GraphQLError } from 'graphql';
 import { checkResultAndHandleErrors, getErrorsFromParent, ERROR_SYMBOL } from '../stitching/errors';
 
 import 'mocha';
 
-class ErrorWithResult extends Error {
+class ErrorWithResult extends GraphQLError {
   public result: any;
   constructor(message: string, result: any) {
     super(message);
@@ -12,11 +12,9 @@ class ErrorWithResult extends Error {
   }
 }
 
-class ErrorWithExtensions extends Error {
-  public extensions: any;
+class ErrorWithExtensions extends GraphQLError {
   constructor(message: string, code: string) {
-    super(message);
-    this.extensions = { code };
+    super(message, null, null, null, null, null, { code });
   }
 }
 
@@ -67,7 +65,7 @@ describe('Errors', () => {
 
     it('persists original errors without a result', () => {
       const result = {
-        errors: [new Error('Test error')]
+        errors: [new GraphQLError('Test error')]
       };
       try {
         checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');
@@ -84,7 +82,10 @@ describe('Errors', () => {
 
     it('combines errors and persists the original errors', () => {
       const result = {
-        errors: [new Error('Error1'), new Error('Error2')]
+        errors: [
+          new GraphQLError('Error1'),
+          new GraphQLError('Error2'),
+        ]
       };
       try {
         checkResultAndHandleErrors(result, {} as GraphQLResolveInfo, 'responseKey');

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -103,27 +103,25 @@ let enumTest = `
 
 let enumSchema: GraphQLSchema;
 
-if (process.env.GRAPHQL_VERSION !== '^0.11') {
-  enumSchema = makeExecutableSchema({
-    typeDefs: enumTest,
-    resolvers: {
-      Color: {
-        RED: '#EA3232',
+enumSchema = makeExecutableSchema({
+  typeDefs: enumTest,
+  resolvers: {
+    Color: {
+      RED: '#EA3232',
+    },
+    NumericEnum: {
+      TEST: 1,
+    },
+    Query: {
+      color() {
+        return '#EA3232';
       },
-      NumericEnum: {
-        TEST: 1,
-      },
-      Query: {
-        color() {
-          return '#EA3232';
-        },
-        numericEnum() {
-          return 1;
-        },
+      numericEnum() {
+        return 1;
       },
     },
-  });
-}
+  },
+});
 
 let linkSchema = `
   """
@@ -199,126 +197,15 @@ let interfaceExtensionTest = `
   }
 `;
 
-if (['^0.11', '^0.12'].indexOf(process.env.GRAPHQL_VERSION) === -1) {
-  interfaceExtensionTest = `
-    extend interface Downloadable {
-      filesize: Int
-    }
+interfaceExtensionTest = `
+  extend interface Downloadable {
+    filesize: Int
+  }
 
-    extend type DownloadableProduct {
-      filesize: Int
-    }
-  `;
-}
-
-if (process.env.GRAPHQL_VERSION === '^0.11') {
-  scalarTest = `
-    # Description of TestScalar.
-    scalar TestScalar
-
-    # Description of AnotherNewScalar.
-    scalar AnotherNewScalar
-
-    # A type that uses TestScalar.
-    type TestingScalar {
-      value: TestScalar
-    }
-
-    type Query {
-      testingScalar: TestingScalar
-    }
-  `;
-
-  enumTest = `
-    # A type that uses an Enum.
-    enum Color {
-      # A vivid color
-      RED
-    }
-
-    # A type that uses an Enum with a numeric constant.
-    enum NumericEnum {
-    # A test description
-      TEST @deprecated(reason: "This is deprecated")
-    }
-
-    schema {
-      query: Query
-    }
-
-    type Query {
-      color: Color
-      numericEnum: NumericEnum
-    }
-  `;
-
-  enumSchema = makeExecutableSchema({
-    typeDefs: enumTest,
-    resolvers: {
-      Color: {
-        RED: '#EA3232',
-      },
-      NumericEnum: {
-        TEST: 1,
-      },
-      Query: {
-        color() {
-          return '#EA3232';
-        },
-        numericEnum() {
-          return 1;
-        },
-      },
-    },
-  });
-
-  linkSchema = `
-    # A new type linking the Property type.
-    type LinkType {
-      test: String
-      # The property.
-      property: Property
-    }
-
-    interface Node {
-      id: ID!
-    }
-
-    extend type Car implements Node {
-      fakeFieldToSatisfyOldGraphQL: String
-    }
-
-    extend type Bike implements Node {
-      fakeFieldToSatisfyOldGraphQL: String
-    }
-
-    extend type Booking implements Node {
-      # The property of the booking.
-      property: Property
-      # A textual description of the booking.
-      textDescription: String
-    }
-
-    extend type Property implements Node {
-      # A list of bookings.
-      bookings(
-        # The maximum number of bookings to retrieve.
-        limit: Int
-      ): [Booking]
-    }
-
-    extend type Query {
-      delegateInterfaceTest: TestInterface
-      delegateArgumentTest(arbitraryArg: Int): Property
-      # A new field on the root query.
-      linkTest: LinkType
-      node(id: ID!): Node
-      nodes: [Node]
-    }
-
-    extend type Customer implements Node {}
-  `;
-}
+  extend type DownloadableProduct {
+    filesize: Int
+  }
+`;
 
 // Miscellaneous typeDefs that exercise uncommon branches for the sake of
 // code coverage.
@@ -2661,40 +2548,38 @@ fragment BookingFragment on Booking {
         });
       });
 
-      if (['^0.11', '^0.12'].indexOf(process.env.GRAPHQL_VERSION) === -1) {
-        it('interface extensions', async () => {
-          const result = await graphql(
-            mergedSchema,
-            `
-              query {
-                products {
-                  id
-                  __typename
-                  ... on Downloadable {
-                    filesize
-                  }
+      it('interface extensions', async () => {
+        const result = await graphql(
+          mergedSchema,
+          `
+            query {
+              products {
+                id
+                __typename
+                ... on Downloadable {
+                  filesize
                 }
               }
-            `,
-          );
+            }
+          `,
+        );
 
-          expect(result).to.deep.equal({
-            data: {
-              products: [
-                {
-                  id: 'pd1',
-                  __typename: 'SimpleProduct',
-                },
-                {
-                  id: 'pd2',
-                  __typename: 'DownloadableProduct',
-                  filesize: 1024,
-                },
-              ],
-            },
-          });
+        expect(result).to.deep.equal({
+          data: {
+            products: [
+              {
+                id: 'pd1',
+                __typename: 'SimpleProduct',
+              },
+              {
+                id: 'pd2',
+                __typename: 'DownloadableProduct',
+                filesize: 1024,
+              },
+            ],
+          },
         });
-      }
+      });
 
       it('arbitrary transforms that return interfaces', async () => {
         const result = await graphql(

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -165,23 +165,6 @@ describe('generating schema from shorthand', () => {
       }
     `;
 
-    if (process.env.GRAPHQL_VERSION === '^0.11') {
-      shorthand = `
-        # A bird species
-        type BirdSpecies {
-          name: String!,
-          wingspan: Int
-        }
-        type RootQuery {
-          species(name: String!): [BirdSpecies]
-        }
-
-        schema {
-          query: RootQuery
-        }
-      `;
-    }
-
     const resolve = {
       RootQuery: {
         species() {
@@ -2464,47 +2447,45 @@ describe('can specify lexical parser options', () => {
     expect(schema.astNode.loc).to.equal(undefined);
   });
 
-  if (process.env.GRAPHQL_VERSION !== '^0.11') {
-    it("can specify 'experimentalFragmentVariables' option", () => {
-      const typeDefs = `
-        type Hello {
-          world(phrase: String): String
-        }
+  it("can specify 'experimentalFragmentVariables' option", () => {
+    const typeDefs = `
+      type Hello {
+        world(phrase: String): String
+      }
 
-        fragment hello($phrase: String = "world") on Hello {
-          world(phrase: $phrase)
-        }
+      fragment hello($phrase: String = "world") on Hello {
+        world(phrase: $phrase)
+      }
 
-        type RootQuery {
-          hello: Hello
-        }
+      type RootQuery {
+        hello: Hello
+      }
 
-        schema {
-          query: RootQuery
-        }
-      `;
+      schema {
+        query: RootQuery
+      }
+    `;
 
-      const resolvers = {
-        RootQuery: {
-          hello() {
-            return {
-              world: (phrase: string) => `hello ${phrase}`,
-            };
-          },
+    const resolvers = {
+      RootQuery: {
+        hello() {
+          return {
+            world: (phrase: string) => `hello ${phrase}`,
+          };
         },
-      };
+      },
+    };
 
-      expect(() => {
-        makeExecutableSchema({
-          typeDefs,
-          resolvers,
-          parseOptions: {
-            experimentalFragmentVariables: true,
-          },
-        });
-      }).to.not.throw();
-    });
-  }
+    expect(() => {
+      makeExecutableSchema({
+        typeDefs,
+        resolvers,
+        parseOptions: {
+          experimentalFragmentVariables: true,
+        },
+      });
+    }).to.not.throw();
+  });
 });
 
 describe('interfaces', () => {
@@ -2534,27 +2515,25 @@ describe('interfaces', () => {
     user { id name }
   }`;
 
-  if (process.env.GRAPHQL_VERSION !== '^0.11') {
-    it('throws if there is no interface resolveType resolver', async () => {
-      const resolvers = {
-        Query: queryResolver,
-      };
-      try {
-        makeExecutableSchema({
-          typeDefs: testSchemaWithInterfaces,
-          resolvers,
-          resolverValidationOptions: { requireResolversForResolveType: true },
-        });
-      } catch (error) {
-        assert.equal(
-          error.message,
-          'Type "Node" is missing a "resolveType" resolver',
-        );
-        return;
-      }
-      throw new Error('Should have had an error.');
-    });
-  }
+  it('throws if there is no interface resolveType resolver', async () => {
+    const resolvers = {
+      Query: queryResolver,
+    };
+    try {
+      makeExecutableSchema({
+        typeDefs: testSchemaWithInterfaces,
+        resolvers,
+        resolverValidationOptions: { requireResolversForResolveType: true },
+      });
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Type "Node" is missing a "resolveType" resolver',
+      );
+      return;
+    }
+    throw new Error('Should have had an error.');
+  });
   it('does not throw if there is an interface resolveType resolver', async () => {
     const resolvers = {
       Query: queryResolver,
@@ -2730,27 +2709,25 @@ describe('unions', () => {
     }
   }`;
 
-  if (process.env.GRAPHQL_VERSION !== '^0.11') {
-    it('throws if there is no union resolveType resolver', async () => {
-      const resolvers = {
-        Query: queryResolver,
-      };
-      try {
-        makeExecutableSchema({
-          typeDefs: testSchemaWithUnions,
-          resolvers,
-          resolverValidationOptions: { requireResolversForResolveType: true },
-        });
-      } catch (error) {
-        assert.equal(
-          error.message,
-          'Type "Displayable" is missing a "resolveType" resolver',
-        );
-        return;
-      }
-      throw new Error('Should have had an error.');
-    });
-  }
+  it('throws if there is no union resolveType resolver', async () => {
+    const resolvers = {
+      Query: queryResolver,
+    };
+    try {
+      makeExecutableSchema({
+        typeDefs: testSchemaWithUnions,
+        resolvers,
+        resolverValidationOptions: { requireResolversForResolveType: true },
+      });
+    } catch (error) {
+      assert.equal(
+        error.message,
+        'Type "Displayable" is missing a "resolveType" resolver',
+      );
+      return;
+    }
+    throw new Error('Should have had an error.');
+  });
   it('does not throw if there is a resolveType resolver', async () => {
     const resolvers = {
       Query: queryResolver,

--- a/src/test/testTransforms.ts
+++ b/src/test/testTransforms.ts
@@ -301,20 +301,11 @@ describe('transforms', () => {
           }
         `,
       );
-      expect(result).to.deep.equal({
-        errors: [
-          {
-            locations: [
-              {
-                column: 15,
-                line: 8,
-              },
-            ],
-            message: 'Cannot query field "customer" on type "Booking".',
-            path: undefined,
-          },
-        ],
-      });
+      expect(result.errors).not.to.be.empty;
+      expect(result.errors.length).to.equal(1);
+      expect(result.errors[0].message).to.equal(
+        'Cannot query field "customer" on type "Booking".'
+      );
     });
   });
 

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -9,6 +9,7 @@ import {
   ExecutionResult,
   DocumentNode,
 } from 'graphql';
+import { ExecutionResultDataDefault } from 'graphql/execution/execute';
 import {
   ApolloLink,
   Observable,
@@ -708,7 +709,7 @@ export async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
         const { graphqlContext } = operation.getContext();
         try {
           if (!hasSubscriptionOperation(operation)) {
-            const result = await graphql(
+            const result: ExecutionResultDataDefault = await graphql(
               schema,
               print(query),
               null,
@@ -732,7 +733,7 @@ export async function makeSchemaRemoteFromLink(schema: GraphQLSchema) {
               'function'
             ) {
               while (true) {
-                const next = await (<AsyncIterator<ExecutionResult>>(
+                const next = await (<AsyncIterator<ExecutionResultDataDefault>>(
                   result
                 )).next();
                 observer.next(next.value as LinkExecutionResult);

--- a/src/transforms/ConvertEnumValues.ts
+++ b/src/transforms/ConvertEnumValues.ts
@@ -1,0 +1,83 @@
+import { GraphQLSchema, GraphQLEnumType } from 'graphql';
+import { Transform } from '../transforms/transforms';
+import { visitSchema, VisitSchemaKind } from '../transforms/visitSchema';
+
+// Transformation used to modifiy `GraphQLEnumType` values in a schema.
+export default class ConvertEnumValues implements Transform {
+  // Maps current enum values to their new values.
+  // e.g. { Color: { 'RED': '#EA3232' } }
+  private enumValueMap: object;
+
+  constructor(enumValueMap: object) {
+    this.enumValueMap = enumValueMap;
+  }
+
+  // Walk a schema looking for `GraphQLEnumType` types. If found, and
+  // matching types have been identified in `this.enumValueMap`, create new
+  // `GraphQLEnumType` types using the `this.enumValueMap` specified new
+  // values, and return them in the new schema.
+  public transformSchema(schema: GraphQLSchema): GraphQLSchema {
+    const { enumValueMap } = this;
+    if (!enumValueMap || Object.keys(enumValueMap).length === 0) {
+      return schema;
+    }
+
+    const transformedSchema = visitSchema(schema, {
+      [VisitSchemaKind.ENUM_TYPE](enumType: GraphQLEnumType) {
+        const externalToInternalValueMap = enumValueMap[enumType.name];
+
+        if (externalToInternalValueMap) {
+          const values = enumType.getValues();
+          const newValues = {};
+          values.forEach((value) => {
+            const newValue =
+              Object.keys(externalToInternalValueMap).includes(value.name)
+                ? externalToInternalValueMap[value.name]
+                : value.name;
+            newValues[value.name] = {
+              value: newValue,
+              deprecationReason: value.deprecationReason,
+              description: value.description,
+              astNode: value.astNode,
+            };
+          });
+
+          return new GraphQLEnumType({
+            name: enumType.name,
+            description: enumType.description,
+            astNode: enumType.astNode,
+            values: newValues,
+          });
+        }
+
+        return enumType;
+      },
+    });
+
+    // `GraphQLEnumType`'s in `graphql-js` 14.x currently use an internal
+    // `_valueLookup` map to associate enum values with the enums
+    // themselves, when doing an enum lookup. To support `graphql-tools`
+    // internal enum values functionality however, we have to change the
+    // enum value used as the key in the `_valueLookup` map, to be the new
+    // internal only enum value. The code above accomplishes this by
+    // creating a new `GraphQLEnumType` with the internal enum value as the
+    // enum value. Unfortunately, doing this breaks the way scheam delegation
+    // works in `graphql-tools`, since delegation can no longer look an enum
+    // up by it's original external facing value. To accommodate this,
+    // here we're switching the enums value back to it's original external
+    // facing value. So `_valueLookup` stays as we want it - with the new
+    // enum value as the key in the lookup map, but the defined enum values
+    // array is now back to the way it was, with only external facing values.
+    const schemaTypeMap = transformedSchema.getTypeMap();
+    Object.keys(enumValueMap).forEach((enumTypeName) => {
+      const enumType = schemaTypeMap[enumTypeName];
+      if (enumType) {
+        (enumType as GraphQLEnumType).getValues().forEach((value) => {
+          value.value = value.name;
+        });
+      }
+    });
+
+    return transformedSchema;
+  }
+}

--- a/src/transforms/ConvertEnumValues.ts
+++ b/src/transforms/ConvertEnumValues.ts
@@ -63,8 +63,8 @@ export default class ConvertEnumValues implements Transform {
     // creating a new `GraphQLEnumType` with the internal enum value as the
     // enum value. Unfortunately, doing this breaks the way scheam delegation
     // works in `graphql-tools`, since delegation can no longer look an enum
-    // up by it's original external facing value. To accommodate this,
-    // here we're switching the enums value back to it's original external
+    // up by its original external facing value. To accommodate this,
+    // here we're switching the enums value back to its original external
     // facing value. So `_valueLookup` stays as we want it - with the new
     // enum value as the key in the lookup map, but the defined enum values
     // array is now back to the way it was, with only external facing values.

--- a/src/transforms/transformSchema.ts
+++ b/src/transforms/transformSchema.ts
@@ -19,7 +19,7 @@ export default function transformSchema(
     transforms,
     mapping,
   );
-  addResolveFunctionsToSchema({
+  schema = addResolveFunctionsToSchema({
     schema,
     resolvers,
     resolverValidationOptions: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist",
-    "removeComments": false
+    "removeComments": false,
+    "noImplicitUseStrict": true,
   },
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
This PR updates the `graphql-tools` `peerDependencies` to allow `graphql` 14.x, and enforces `graphql` 14.x in its `devDependencies`. All changes have been made in a way that is backwards compatible with `graphql` 0.13.x, but anyone looking to upgrade to `graphql` 14.x should keep in mind that [`graphql` 14.x introduced several breaking changes](https://github.com/graphql/graphql-js/releases/tag/v14.0.0). Because of this we're likely going to major version bump `graphql-tools` for the next release.

Most of the changes in this PR are pretty straightforward, with one main exception. The current version of `graphql-tools` is relying on `graphql` 0.13 functionality to achieve [internal enum value support](https://www.apollographql.com/docs/graphql-tools/scalars.html#internal-values). `graphql` 14.x has tightened up public facing API access, which means the current method of handling internal enum values no longer works with `graphql` 14.x. Because of this, we now have to transform existing enums into new enums that include an internal value. This means we're adding a new schema transformation step to schema's that include enums with enum resolvers. 

Fixes #945.

Work remaining: 
- [x] Update `@types/graphql`
- [x] Allow `graphql` 14.x in all peer projects and get new versions published (`apollo-link`, `graphql-subscriptions`)
- [x] Stop running CI on Node 4; Add in Node 10
