### PR TITLE
Fix regression in enum input -> internal value conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNext
+
+* Fix regression in enum input mapping.
+
 ### 4.0.1
 
 * Fix [regression](https://github.com/apollographql/graphql-tools/issues/962) in enum internal value mapping.  <br/>

--- a/src/stitching/delegateToSchema.ts
+++ b/src/stitching/delegateToSchema.ts
@@ -14,13 +14,10 @@ import {
   GraphQLSchema,
   ExecutionResult,
   NameNode,
+  isEnumType,
 } from 'graphql';
 
-import {
-  Operation,
-  Request,
-  IDelegateToSchemaOptions,
-} from '../Interfaces';
+import { Operation, Request, IDelegateToSchemaOptions } from '../Interfaces';
 
 import {
   applyRequestTransforms,
@@ -34,6 +31,7 @@ import CheckResultAndHandleErrors from '../transforms/CheckResultAndHandleErrors
 import mapAsyncIterator from './mapAsyncIterator';
 import ExpandAbstractTypes from '../transforms/ExpandAbstractTypes';
 import ReplaceFieldWithFragment from '../transforms/ReplaceFieldWithFragment';
+import ConvertEnumResponse from '../transforms/ConvertEnumResponse';
 
 export default function delegateToSchema(
   options: IDelegateToSchemaOptions | GraphQLSchema,
@@ -42,7 +40,7 @@ export default function delegateToSchema(
   if (options instanceof GraphQLSchema) {
     throw new Error(
       'Passing positional arguments to delegateToSchema is a deprecated. ' +
-      'Please pass named parameters instead.'
+        'Please pass named parameters instead.',
     );
   }
   return delegateToSchemaImplementation(options);
@@ -71,12 +69,12 @@ async function delegateToSchemaImplementation(
 
   let transforms = [
     ...(options.transforms || []),
-    new ExpandAbstractTypes(info.schema, options.schema)
+    new ExpandAbstractTypes(info.schema, options.schema),
   ];
 
   if (info.mergeInfo && info.mergeInfo.fragments) {
     transforms.push(
-      new ReplaceFieldWithFragment(options.schema, info.mergeInfo.fragments)
+      new ReplaceFieldWithFragment(options.schema, info.mergeInfo.fragments),
     );
   }
 
@@ -84,8 +82,14 @@ async function delegateToSchemaImplementation(
     new AddArgumentsAsVariables(options.schema, args),
     new FilterToSchema(options.schema),
     new AddTypenameToAbstract(options.schema),
-    new CheckResultAndHandleErrors(info, options.fieldName)
+    new CheckResultAndHandleErrors(info, options.fieldName),
   ]);
+
+  if (isEnumType(options.info.returnType)) {
+    transforms = transforms.concat(
+      new ConvertEnumResponse(options.info.returnType),
+    );
+  }
 
   const processedRequest = applyRequestTransforms(rawRequest, transforms);
 
@@ -110,16 +114,16 @@ async function delegateToSchemaImplementation(
   }
 
   if (operation === 'subscription') {
-    const executionResult = await subscribe(
+    const executionResult = (await subscribe(
       options.schema,
       processedRequest.document,
       info.rootValue,
       options.context,
       processedRequest.variables,
-    ) as AsyncIterator<ExecutionResult>;
+    )) as AsyncIterator<ExecutionResult>;
 
     // "subscribe" to the subscription result and map the result through the transforms
-    return mapAsyncIterator<ExecutionResult, any>(executionResult, (result) => {
+    return mapAsyncIterator<ExecutionResult, any>(executionResult, result => {
       const transformedResult = applyResultTransforms(result, transforms);
       const subscriptionKey = Object.keys(result.data)[0];
 

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -714,14 +714,18 @@ bookingById(id: "b1") {
               throwError: null,
             },
           } as any,
-          errors: [{
-            message: 'subscription field error',
-            path: ['notifications', 'throwError'],
-            locations: [{
-              line: 4,
-              column: 15,
-            }],
-          }],
+          errors: [
+            {
+              message: 'subscription field error',
+              path: ['notifications', 'throwError'],
+              locations: [
+                {
+                  line: 4,
+                  column: 15,
+                },
+              ],
+            },
+          ],
         };
 
         const subscription = parse(`
@@ -752,7 +756,6 @@ bookingById(id: "b1") {
 
         subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
       });
-
 
       it('links in queries', async () => {
         const mergedResult = await graphql(

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -1045,7 +1045,7 @@ describe('generating schema from shorthand', () => {
       });
     });
 
-    it.only('supports resolving the value for a GraphQLEnumType in input types', () => {
+    it('supports resolving the value for a GraphQLEnumType in input types', () => {
       const shorthand = `
         enum Color {
           RED

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -1044,6 +1044,65 @@ describe('generating schema from shorthand', () => {
         assert.equal(result.errors, undefined);
       });
     });
+
+    it.only('supports resolving the value for a GraphQLEnumType in input types', () => {
+      const shorthand = `
+        enum Color {
+          RED
+          BLUE
+        }
+
+        enum NumericEnum {
+          TEST
+        }
+
+        schema {
+          query: Query
+        }
+
+        type Query {
+          colorTest(color: Color): String
+          numericTest(num: NumericEnum): Int
+        }
+      `;
+
+      const testQuery = `{
+        red: colorTest(color: RED)
+        blue: colorTest(color: BLUE)
+        num: numericTest(num: TEST)
+       }`;
+
+      const resolveFunctions = {
+        Color: {
+          RED: '#EA3232',
+          BLUE: '#0000FF',
+        },
+        NumericEnum: {
+          TEST: 1,
+        },
+        Query: {
+          colorTest(root: any, args: { color: string }) {
+            return args.color;
+          },
+          numericTest(root: any, args: { num: number }) {
+            return args.num;
+          },
+        },
+      };
+
+      const jsSchema = makeExecutableSchema({
+        typeDefs: shorthand,
+        resolvers: resolveFunctions,
+      });
+
+      const resultPromise = graphql(jsSchema, testQuery);
+      return resultPromise.then(result => {
+        assert.equal(result.data['red'], resolveFunctions.Color.RED);
+        assert.equal(result.data['blue'], resolveFunctions.Color.BLUE);
+        assert.equal(result.data['num'], resolveFunctions.NumericEnum.TEST);
+        assert.equal(result.errors, undefined);
+      });
+    });
   });
 
   it('can set description and deprecation reason', () => {

--- a/src/transforms/ConvertEnumResponse.ts
+++ b/src/transforms/ConvertEnumResponse.ts
@@ -1,0 +1,18 @@
+import { Transform } from './transforms';
+import { GraphQLEnumType } from 'graphql';
+
+export default class ConvertEnumResponse implements Transform {
+  private enumNode: GraphQLEnumType;
+
+  constructor(enumNode: GraphQLEnumType) {
+    this.enumNode = enumNode;
+  }
+
+  public transformResult(result: any) {
+    const value = this.enumNode.getValue(result);
+    if (value) {
+      return value.value;
+    }
+    return result;
+  }
+}

--- a/src/transforms/ConvertEnumValues.ts
+++ b/src/transforms/ConvertEnumValues.ts
@@ -29,11 +29,12 @@ export default class ConvertEnumValues implements Transform {
         if (externalToInternalValueMap) {
           const values = enumType.getValues();
           const newValues = {};
-          values.forEach((value) => {
-            const newValue =
-              Object.keys(externalToInternalValueMap).includes(value.name)
-                ? externalToInternalValueMap[value.name]
-                : value.name;
+          values.forEach(value => {
+            const newValue = Object.keys(externalToInternalValueMap).includes(
+              value.name,
+            )
+              ? externalToInternalValueMap[value.name]
+              : value.name;
             newValues[value.name] = {
               value: newValue,
               deprecationReason: value.deprecationReason,
@@ -52,30 +53,6 @@ export default class ConvertEnumValues implements Transform {
 
         return enumType;
       },
-    });
-
-    // `GraphQLEnumType`'s in `graphql-js` 14.x currently use an internal
-    // `_valueLookup` map to associate enum values with the enums
-    // themselves, when doing an enum lookup. To support `graphql-tools`
-    // internal enum values functionality however, we have to change the
-    // enum value used as the key in the `_valueLookup` map, to be the new
-    // internal only enum value. The code above accomplishes this by
-    // creating a new `GraphQLEnumType` with the internal enum value as the
-    // enum value. Unfortunately, doing this breaks the way scheam delegation
-    // works in `graphql-tools`, since delegation can no longer look an enum
-    // up by its original external facing value. To accommodate this,
-    // here we're switching the enums value back to its original external
-    // facing value. So `_valueLookup` stays as we want it - with the new
-    // enum value as the key in the lookup map, but the defined enum values
-    // array is now back to the way it was, with only external facing values.
-    const schemaTypeMap = transformedSchema.getTypeMap();
-    Object.keys(enumValueMap).forEach((enumTypeName) => {
-      const enumType = schemaTypeMap[enumTypeName];
-      if (enumType) {
-        (enumType as GraphQLEnumType).getValues().forEach((value) => {
-          value.value = value.name;
-        });
-      }
     });
 
     return transformedSchema;


### PR DESCRIPTION
Fixes the inverse of https://github.com/apollographql/graphql-tools/pull/973, values on input should be mapped to their internal values. This was broken because of the changes [noted here](https://github.com/apollographql/graphql-tools/blob/6c0f4294d8449dc26bbe832feb5c4ce4df35cec0/src/transforms/ConvertEnumValues.ts#L57-L79). I took what this was trying to achieve and moved it into a separate transform specific to merged schema delegation. Tests included.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->