### PR TITLE
Add support for passing parsed schema ast to mergeSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Update package.json `repository` field. <br />
   [@dlukeomalley](https://github.com/dlukeomalley) in
   [#979](https://github.com/apollographql/graphql-tools/pull/979)
+* Add support for passing a parsed schema ast to `mergeSchemas` <br/>
+  [@ganemone](https://github.com/ganemone) in
+  [#977](https://github.com/apollographql/graphql-tools/pull/977)
 
 ### 4.0.2
 

--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -291,7 +291,7 @@ For a more complicated example involving properties and bookings, with implement
 
 ```ts
 mergeSchemas({
-  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
+  schemas: Array<string | GraphQLSchema | DocumentNode | Array<GraphQLNamedType>>;
   resolvers?: Array<IResolvers> | IResolvers;
   onTypeConflict?: (
     left: GraphQLNamedType,

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -10,6 +10,7 @@ import {
   getNamedType,
   isNamedType,
   parse,
+  Kind
 } from 'graphql';
 import {
   IDelegateToSchemaOptions,
@@ -60,7 +61,7 @@ export default function mergeSchemas({
   schemaDirectives,
   inheritResolversFromInterfaces
 }: {
-  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
+  schemas: Array<string | GraphQLSchema | DocumentNode | Array<GraphQLNamedType>>;
   onTypeConflict?: OnTypeConflict;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
@@ -75,7 +76,7 @@ function mergeSchemasImplementation({
   schemaDirectives,
   inheritResolversFromInterfaces
 }: {
-  schemas: Array<string | GraphQLSchema | Array<GraphQLNamedType>>;
+  schemas: Array<string | GraphQLSchema | DocumentNode | Array<GraphQLNamedType>>;
   resolvers?: IResolversParameter;
   schemaDirectives?: { [name: string]: typeof SchemaDirectiveVisitor };
   inheritResolversFromInterfaces?: boolean;
@@ -137,8 +138,8 @@ function mergeSchemasImplementation({
           });
         }
       });
-    } else if (typeof schema === 'string') {
-      let parsedSchemaDocument = parse(schema);
+    } else if (typeof schema === 'string' || (schema && (schema as DocumentNode).kind === Kind.DOCUMENT)) {
+      let parsedSchemaDocument = typeof schema === 'string' ? parse(schema) : (schema as DocumentNode);
       parsedSchemaDocument.definitions.forEach(def => {
         const type = typeFromAST(def);
         if (type) {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -190,6 +190,7 @@ const loneExtend = parse(`
   }
 `);
 
+
 let interfaceExtensionTest = `
   # No-op for older versions since this feature does not yet exist
   extend type DownloadableProduct {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -190,7 +190,6 @@ const loneExtend = parse(`
   }
 `);
 
-
 let interfaceExtensionTest = `
   # No-op for older versions since this feature does not yet exist
   extend type DownloadableProduct {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -184,11 +184,11 @@ let linkSchema = `
   extend type Customer implements Node
 `;
 
-const loneExtend = `
+const loneExtend = parse(`
   extend type Booking {
     foo: String!
   }
-`;
+`);
 
 let interfaceExtensionTest = `
   # No-op for older versions since this feature does not yet exist


### PR DESCRIPTION
Many APIs across graphql-tools and apollo libraries support passing
a parsed graphql ast or a graphql string. For example, makeExecutableSchema.
This PR updates the mergeSchemas API to support passing a parsed graphql ast.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->