### PR TITLE
Update package.json `repository` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+### vNext
+
+* Update package.json `repository` field. <br />
+  [@dlukeomalley](https://github.com/dlukeomalley) in
+  [#979](https://github.com/apollographql/graphql-tools/pull/979)
+
 ### 4.0.2
 
 * Fix regression in enum input mapping.  <br/>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/apollostack/graphql-tools.git"
+    "url": "git+https://github.com/apollographql/graphql-tools.git"
   },
   "keywords": [
     "GraphQL",


### PR DESCRIPTION
Updated the package.json `repository` field to reflect the current location of the repo (github.com/apollographql/graphql-tools). Making the fix because some of my tooling doesn't follow GitHub's redirects from `apollostack` -> `apollographql` :)

TODO:

- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.