### PR TITLE
Fix invalid query in schema delegation example

### DIFF
--- a/docs/source/schema-delegation.md
+++ b/docs/source/schema-delegation.md
@@ -73,7 +73,10 @@ query {
     repositories {
       id
       url
-      user
+      user {
+        username
+        id
+      }
       issues {
         text
       }


### PR DESCRIPTION
No `user` subfield were queried in the example, so the query was invalid.