### PR TITLE
Fix regression where custom scalars are incorrectly replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   [#977](https://github.com/apollographql/graphql-tools/pull/977)
 * Changes to `extractExtensionDefinitions` to support `graphql-js` union and enum extensions.  <br/>
   [@jansuchy](https://github.com/jansuchy) in [#951](https://github.com/apollographql/graphql-tools/pull/951)
+* Fix regression where custom scalars were incorrectly replaced while recreating schema with `visitSchema`.  <br/>
+  [@tgriesser](https://github.com/tgriesser) in [#985](https://github.com/apollographql/graphql-tools/pull/985)
 
 ### 4.0.2
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -101,7 +101,7 @@ export function recreateType(
       values: newValues,
     });
   } else if (type instanceof GraphQLScalarType) {
-    if (isSpecifiedScalarType(type)) {
+    if (keepResolvers || isSpecifiedScalarType(type)) {
       return type;
     } else {
       return new GraphQLScalarType({


### PR DESCRIPTION
Fixes a regression where custom scalars were incorrectly replaced while recreating schema with `visitSchema`. `visitSchema` is used internally to replace the enums when the internal enum value mapping is used. However, because of a missing check for `keepResolvers`, all user-defined scalars are actually being replaced with a passthrough scalar:

```ts
return new GraphQLScalarType({
  name: type.name,
  description: type.description,
  astNode: type.astNode,
  serialize(value: any) {
    return value;
  },
  parseValue(value: any) {
    return value;
  },
  parseLiteral(ast: ValueNode) {
    return parseLiteral(ast);
  },
});
```

This means any user-defined formatting is broken/removed. Test included.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

/label bug

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->