### PR TITLE
Update resolvers.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Make `WrapQuery` work for non-root fields <br />
   [@mdlavin](https://github.com/mdlavin) in
   [#1007](https://github.com/apollographql/graphql-tools/pull/1008)
+* Update resolvers.md to clarify array usage <br />
+  [@alvin777](https://github.com/alvin777) in
+  [#1005](https://github.com/apollographql/graphql-tools/pull/1005)
 
 ### 4.0.3
 

--- a/docs/source/resolvers.md
+++ b/docs/source/resolvers.md
@@ -54,8 +54,8 @@ Resolvers in GraphQL can return different kinds of results which are treated dif
 1. `null` or `undefined` - this indicates the object could not be found. If your schema says that field is _nullable_, then the result will have a `null` value at that position. If the field is `non-null`, the result will "bubble up" to the nearest nullable field and that result will be set to `null`. This is to ensure that the API consumer never gets a `null` value when they were expecting a result.
 2. An array - this is only valid if the schema indicates that the result of a field should be a list. The sub-selection of the query will run once for every item in this array.
 3. A promise - resolvers often do asynchronous actions like fetching from a database or backend API, so they can return promises. This can be combined with arrays, so a resolver can return: 
-    1. a promise that resolves an array
-    2. an array of promises
+    1. A promise that resolves an array
+    2. An array of promises
 4. A scalar or object value - a resolver can also return any other kind of value, which doesn't have any special meaning but is simply passed down into any nested resolvers, as described in the next section.
 
 ### Resolver obj argument

--- a/docs/source/resolvers.md
+++ b/docs/source/resolvers.md
@@ -53,7 +53,9 @@ Resolvers in GraphQL can return different kinds of results which are treated dif
 
 1. `null` or `undefined` - this indicates the object could not be found. If your schema says that field is _nullable_, then the result will have a `null` value at that position. If the field is `non-null`, the result will "bubble up" to the nearest nullable field and that result will be set to `null`. This is to ensure that the API consumer never gets a `null` value when they were expecting a result.
 2. An array - this is only valid if the schema indicates that the result of a field should be a list. The sub-selection of the query will run once for every item in this array.
-3. A promise - resolvers often do asynchronous actions like fetching from a database or backend API, so they can return promises. This can be combined with arrays, so a resolver can return a promise that resolves to an array, or an array of promises, and both are handled correctly.
+3. A promise - resolvers often do asynchronous actions like fetching from a database or backend API, so they can return promises. This can be combined with arrays, so a resolver can return: 
+    1. a promise that resolves an array
+    2. an array of promises
 4. A scalar or object value - a resolver can also return any other kind of value, which doesn't have any special meaning but is simply passed down into any nested resolvers, as described in the next section.
 
 ### Resolver obj argument


### PR DESCRIPTION
Phrase '<they can return> a promise that resolves to an array, or an array of promises' can be read as
1. <they can return> ((a promise that resolves to an array), or (an array of promises)) <-- correct
2. <they can return> a promise that resolves to ((an array), or (an array of promises))

Oxford comma supposed to make this statement clear, but for non-native speakers like me it makes sense to emphasize the first reading.

Proposed solution:
```
... so a resolver can return: 
    1. a promise that resolves an array
    2. an array of promises
```

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

