### PR TITLE
Avoid infinite loop when using WrapQuery on second level fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-* Make WrapQuery work for non-root fields <br />
+* Make `WrapQuery` work for non-root fields <br />
   [@mdlavin](https://github.com/mdlavin) in
   [#1007](https://github.com/apollographql/graphql-tools/pull/1008)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+### vNext
+
+* Make WrapQuery work for non-root fields <br />
+  [@mdlavin](https://github.com/mdlavin) in
+  [#1007](https://github.com/apollographql/graphql-tools/pull/1008)
+
 ### 4.0.3
 
 * Replaced broken link in docs homepage with Launchpad example <br />
@@ -17,7 +23,7 @@
 * Changes to `extractExtensionDefinitions` to support `graphql-js` union and enum extensions.  <br/>
   [@jansuchy](https://github.com/jansuchy) in [#951](https://github.com/apollographql/graphql-tools/pull/951)
 * Add docs for `mockServer` (closes [#951](https://github.com/apollographql/graphql-tools/issues/94))<br/>
-  [@mfix22](https://github.com/mfix22) in [PR #982](https://github.com/apollographql/graphql-tools/pull/982)  
+  [@mfix22](https://github.com/mfix22) in [PR #982](https://github.com/apollographql/graphql-tools/pull/982)
 * Fix regression where custom scalars were incorrectly replaced while recreating schema with `visitSchema`.  <br/>
   [@tgriesser](https://github.com/tgriesser) in [#985](https://github.com/apollographql/graphql-tools/pull/985)
 

--- a/src/test/testTransforms.ts
+++ b/src/test/testTransforms.ts
@@ -665,6 +665,12 @@ describe('transforms', () => {
                       zip: result.addressZip
                     })
                   ),
+                  // Wrap a second level field
+                  new WrapQuery(
+                    ['userById', 'zip'],
+                    (subtree: SelectionSetNode) => subtree,
+                    result => result
+                  )
                 ],
               });
             },

--- a/src/transforms/WrapQuery.ts
+++ b/src/transforms/WrapQuery.ts
@@ -53,11 +53,12 @@ export default class WrapQuery implements Transform {
   }
 
   public transformResult(originalResult: Result): Result {
-    let data = originalResult.data;
-    if (data) {
+    const rootData = originalResult.data;
+    if (rootData) {
+      let data = rootData;
       const path = [...this.path];
       while (path.length > 1) {
-        const next = path.unshift();
+        const next = path.shift();
         if (data[next]) {
           data = data[next];
         }
@@ -66,7 +67,7 @@ export default class WrapQuery implements Transform {
     }
 
     return {
-      data,
+      data: rootData,
       errors: originalResult.errors
     };
   }


### PR DESCRIPTION
Before the fix provided, the new testcase would get stuck in an infinite loop. The use of `unshift` was not correct.

Fixes #1007 

