### PR TITLE
Fix mockServer example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Add missing property to `mergeSchemas` api reference. <br />
   [@PlayMa256](https://github.com/PlayMa256) in
   [#1014](https://github.com/apollographql/graphql-tools/pull/1014)
+* Documentation updates.  <br/>
+  [@dougshamoo](https://github.com/dougshamoo) in [#1012](https://github.com/apollographql/graphql-tools/pull/1012)
 
 ### 4.0.3
 

--- a/docs/source/mocking.md
+++ b/docs/source/mocking.md
@@ -245,11 +245,15 @@ This is an object you can return from your mock resolvers which calls the `mockF
 ```js
 import { mockServer } from 'graphql-tools';
 
-const server = mockServer({
-  schema,
-  mocks: {},
-  preserveResolvers: false,
-});
+// This can be an SDL schema string (eg the result of `buildClientSchema` above)
+// or a GraphQLSchema object (eg the result of `buildSchema` from `graphql`)
+const schema = `...`
+
+// Same mocks object that `addMockFunctionsToSchema` takes above
+const mocks = {}
+preserveResolvers = false
+
+const server = mockServer(schemaString, mocks, preserveResolvers);
 
 const query = `{ __typename }`
 const variables = {}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

For reference, the mockServer function signature: https://github.com/apollographql/graphql-tools/blob/b85137ba81c9bdc5667bced9cad9b1d226ea83fc/src/mock.ts#L34-L38

I recently set up graphql mocking for the test environment in one of our apps, and it took me way longer than I care to admit to figure out that the single doc describing how to use `mockServer` was incorrect (should have looked at the source code a lot earlier in retrospect). This change fixes the example and adds a little more info to help prevent people from going down the wrong path.

All that being said, in the future I think I would prefer to see the `mockServer` function take an object of named parameters like many of the other related functions (notably `makeExecutableSchema` and `addMockFunctionsToSchema` which are described in the same doc and take confusingly similar arguments). So, I wouldn't be upset if this PR turned into that.

Thanks for all the hard work.