### PR TITLE
Change IFieldResolver args to type any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   [@dougshamoo](https://github.com/dougshamoo) in [#1012](https://github.com/apollographql/graphql-tools/pull/1012)
 * Fix default merged resolver behavior <br/>
   [@mfix22](https://github.com/mfix22) in [#983](https://github.com/apollographql/graphql-tools/pull/983)
+* Fix `IFieldResolver`, changed TArgs default value to `any` 
+  in response to [#1001](https://github.com/apollographql/graphql-tools/issues/1001) <br />
+  [@jcloutz](https://github.com/jcloutz) in [#1017](https://github.com/apollographql/graphql-tools/pull/1017)
 
 ### 4.0.3
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -32,10 +32,10 @@ export interface IAddResolveFunctionsToSchemaOptions {
   inheritResolversFromInterfaces?: boolean;
 }
 
-export interface IResolverOptions<TSource = any, TContext = any> {
+export interface IResolverOptions<TSource = any, TContext = any, TArgs = any> {
   fragment?: string;
-  resolve?: IFieldResolver<TSource, TContext>;
-  subscribe?: IFieldResolver<TSource, TContext>;
+  resolve?: IFieldResolver<TSource, TContext, TArgs>;
+  subscribe?: IFieldResolver<TSource, TContext, TArgs>;
   __resolveType?: GraphQLTypeResolver<TSource, TContext>;
   __isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext>;
 }
@@ -77,7 +77,7 @@ export type MergeInfo = {
   }>;
 };
 
-export type IFieldResolver<TSource, TContext, TArgs = { [argument: string]: any }> = (
+export type IFieldResolver<TSource, TContext, TArgs = any> = (
   source: TSource,
   args: TArgs,
   context: TContext,

--- a/src/stitching/mergeSchemas.ts
+++ b/src/stitching/mergeSchemas.ts
@@ -360,7 +360,7 @@ function createDelegatingResolver(
   schema: GraphQLSchema,
   operation: 'query' | 'mutation' | 'subscription',
   fieldName: string,
-): IFieldResolver<any, any> {
+): IFieldResolver<any, any, any> {
   return (root, args, context, info) => {
     return info.mergeInfo.delegateToSchema({
       schema,


### PR DESCRIPTION
- Change IFieldResolver TArgs default value to `any`
- Change IResolverOptions TArgs default value to `any`
- Update all usages of IFieldResolver
    - Add TArgs paramater to IResolverOptions.resolve and IResolverOptions.subscribe
    - Add TArgs parameter to createDelegatingResolver return value

Relates to #1001 

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.
