### PR TITLE
Docs: update source code link for `info` argument

### DIFF
--- a/docs/source/resolvers.md
+++ b/docs/source/resolvers.md
@@ -45,7 +45,7 @@ These arguments have the following meanings and conventional names:
 1. `obj`: The object that contains the result returned from the resolver on the parent field, or, in the case of a top-level `Query` field, the `rootValue` passed from the [server configuration](/docs/apollo-server/setup.html). This argument enables the nested nature of GraphQL queries.
 2. `args`: An object with the arguments passed into the field in the query. For example, if the field was called with `author(name: "Ada")`, the `args` object would be: `{ "name": "Ada" }`.
 3. `context`: This is an object shared by all resolvers in a particular query, and is used to contain per-request state, including authentication information, dataloader instances, and anything else that should be taken into account when resolving the query. If you're using Apollo Server, [read about how to set the context in the setup documentation](/docs/apollo-server/essentials/data.html#context).
-4. `info`: This argument should only be used in advanced cases, but it contains information about the execution state of the query, including the field name, path to the field from the root, and more. It's only documented in the [GraphQL.js source code](https://github.com/graphql/graphql-js/blob/c82ff68f52722c20f10da69c9e50a030a1f218ae/src/type/definition.js#L489-L500).
+4. `info`: This argument should only be used in advanced cases, but it contains information about the execution state of the query, including the field name, path to the field from the root, and more. It's only documented in the [GraphQL.js source code](https://github.com/graphql/graphql-js/blob/383c0d16b062d06b54ab29a841e762db92f296dd/src/type/definition.js#L792-L803).
 
 ### Resolver result format
 


### PR DESCRIPTION
In the resolver docs, the source code link for the `info` argument pointed to commit that was more than two years old and which had an outdated schema.

Before:
```ts
export type GraphQLResolveInfo = {
  fieldName: string;
  fieldASTs: Array<Field>; // <-- oh no, this field name is wrong!
  returnType: GraphQLOutputType;
  parentType: GraphQLCompositeType;
  path: Array<string | number>;
  schema: GraphQLSchema;
  fragments: { [fragmentName: string]: FragmentDefinition };
  rootValue: mixed;
  operation: OperationDefinition;
  variableValues: { [variableName: string]: mixed };
};
```

After:
```ts
export type GraphQLResolveInfo = {|
  +fieldName: string,
  +fieldNodes: $ReadOnlyArray<FieldNode>, // <-- that's better
  +returnType: GraphQLOutputType,
  +parentType: GraphQLObjectType,
  +path: ResponsePath,
  +schema: GraphQLSchema,
  +fragments: ObjMap<FragmentDefinitionNode>,
  +rootValue: mixed,
  +operation: OperationDefinitionNode,
  +variableValues: { [variable: string]: mixed },
|};
```