### PR TITLE
Fix mocking interfaces example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 * Fix default merged resolver behavior <br/>
   [@mfix22](https://github.com/mfix22) in [#983](https://github.com/apollographql/graphql-tools/pull/983)
 * Use `TArgs` generic wherever `IFieldResolver` is used.  <br/>
-  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)  
+  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)
+* Fix mocking interfaces example <br/>
+  [@danielsbird](https://github.com/danielsbird) in [#1029](https://github.com/apollographql/graphql-tools/pull/1029)
 
 ### 4.0.3
 

--- a/docs/source/mocking.md
+++ b/docs/source/mocking.md
@@ -187,7 +187,7 @@ const typeResolvers = {
 
 const schema = makeExecutableSchema({
   typeDefs,
-  typeResolvers
+  resolvers: typeResolvers
 })
 
 addMockFunctionsToSchema({


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

The [Mocking Interfaces example](https://www.apollographql.com/docs/graphql-tools/mocking.html) shows `makeExecutableSchema` being called with an object with a key named `typeResolvers`. But the [API documentation](https://www.apollographql.com/docs/apollo-server/api/graphql-tools.html#makeExecutableSchema) for `makeExecutableSchema` shows it being called with an object with a key named `resolvers`. I believe the API documentation is correct.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

