### PR TITLE
Fix type declaration for SchemaVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### vNext
 
+* Fix `SchemaVisitor` type declaration to allow null and undefined return values <br />
+  [@rexxars](https://github.com/rexxars) in
+  [#1030](https://github.com/apollographql/graphql-tools/pull/1030)
 * Make `WrapQuery` work for non-root fields <br />
   [@mdlavin](https://github.com/mdlavin) in
   [#1007](https://github.com/apollographql/graphql-tools/pull/1008)

--- a/src/transforms/visitSchema.ts
+++ b/src/transforms/visitSchema.ts
@@ -28,12 +28,12 @@ export enum VisitSchemaKind {
   MUTATION = 'VisitSchemaKind.MUTATION',
   SUBSCRIPTION = 'VisitSchemaKind.SUBSCRIPTION',
 }
-// I couldn't make keys to be forced to be enum values
-export type SchemaVisitor = { [key: string]: TypeVisitor };
+
+export type SchemaVisitor = { [key in VisitSchemaKind]?: TypeVisitor };
 export type TypeVisitor = (
   type: GraphQLType,
   schema: GraphQLSchema,
-) => GraphQLNamedType;
+) => GraphQLNamedType | null | undefined;
 
 export function visitSchema(
   schema: GraphQLSchema,
@@ -57,7 +57,7 @@ export function visitSchema(
       const specifiers = getTypeSpecifiers(type, schema);
       const typeVisitor = getVisitor(visitor, specifiers);
       if (typeVisitor) {
-        const result: GraphQLNamedType | null | undefined = typeVisitor(
+        const result = typeVisitor(
           type,
           schema,
         );


### PR DESCRIPTION
`SchemaVisitor` has two problems currently;
1. It allows any string as key, instead of the predefined enum values.
2. The return type says it cannot return null or undefined, which are both used and have logic applied to them (null removes, undefined recreates as-is)

This PR fixes these two problems so it is possible to use this for filtering types in a typescript project.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

