### PR TITLE
Allow defaultMergedResolver to resolve renamed field result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 * Fix default merged resolver behavior <br/>
   [@mfix22](https://github.com/mfix22) in [#983](https://github.com/apollographql/graphql-tools/pull/983)
 * Use `TArgs` generic wherever `IFieldResolver` is used.  <br/>
-  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)  
+  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)
+* Resolve original AST field name in `getResponseKeyFromInfo` for [#997] <br/>
+  [@kommander](https://github.com/kommander) in [#1036]
+  (https://github.com/apollographql/graphql-tools/pull/1036)
 
 ### 4.0.3
 

--- a/src/stitching/getResponseKeyFromInfo.ts
+++ b/src/stitching/getResponseKeyFromInfo.ts
@@ -1,10 +1,15 @@
 import { GraphQLResolveInfo } from 'graphql';
 
 /**
- * Get the key under which the result of this resolver will be placed in the response JSON. Basically, just
- * resolves aliases.
+ * Get the key under which the result of this resolver will be placed in the response JSON.
+ * Resolves aliases and tries to get the original AST name for the field, in case it was renamed.
  * @param info The info argument to the resolver.
  */
 export function getResponseKeyFromInfo(info: GraphQLResolveInfo) {
-  return info.fieldNodes[0].alias ? info.fieldNodes[0].alias.value : info.fieldName;
+  let fieldName = info.fieldNodes[0].alias ? info.fieldNodes[0].alias.value : info.fieldName;
+  const field = info.parentType.getFields()[fieldName];
+  if (field && field.astNode) {
+    fieldName = field.astNode.name.value;
+  }
+  return fieldName;
 }


### PR DESCRIPTION
Resolve original `fieldName` in `getResponseKeyFromInfo` when using `RenameRootFields` transform for #997.
