### PR TITLE
Include deprecations from string SDL in mergeSchemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 * Fix default merged resolver behavior <br/>
   [@mfix22](https://github.com/mfix22) in [#983](https://github.com/apollographql/graphql-tools/pull/983)
 * Use `TArgs` generic wherever `IFieldResolver` is used.  <br/>
-  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)  
+  [@brikou](https://github.com/brikou) in [#955](https://github.com/apollographql/graphql-tools/pull/955)
+* Include deprecations from string SDL in mergeSchemas.  <br/>
+  [@evans](https://github.com/evans) in [#1041](https://github.com/apollographql/graphql-tools/pull/1041)
 
 ### 4.0.3
 

--- a/src/stitching/typeFromAST.ts
+++ b/src/stitching/typeFromAST.ts
@@ -23,7 +23,9 @@ import {
   UnionTypeDefinitionNode,
   valueFromAST,
   getDescription,
-  GraphQLString
+  GraphQLString,
+  GraphQLFieldConfig,
+  StringValueNode,
 } from 'graphql';
 import resolveFromParentType from './resolveFromParentTypename';
 
@@ -139,13 +141,31 @@ function makeInputObjectType(
   });
 }
 
-function makeFields(nodes: ReadonlyArray<FieldDefinitionNode>) {
-  const result = {};
-  nodes.forEach(node => {
+function makeFields(
+  nodes: ReadonlyArray<FieldDefinitionNode>,
+): Record<string, GraphQLFieldConfig<any, any>> {
+  const result: Record<string, GraphQLFieldConfig<any, any>> = {};
+  nodes.forEach((node) => {
+    const deprecatedDirective = node.directives.find(
+      (directive) =>
+        directive && directive.name && directive.name.value === 'deprecated',
+    );
+    const deprecatedArgument =
+      deprecatedDirective &&
+      deprecatedDirective.arguments &&
+      deprecatedDirective.arguments.find(
+        (arg) => arg && arg.name && arg.name.value === 'reason',
+      );
+    const deprecationReason =
+      deprecatedArgument &&
+      deprecatedArgument.value &&
+      (deprecatedArgument.value as StringValueNode).value;
+
     result[node.name.value] = {
-      type: resolveType(node.type, 'object'),
+      type: resolveType(node.type, 'object') as GraphQLObjectType,
       args: makeValues(node.arguments),
       description: getDescription(node, backcompatOptions),
+      deprecationReason,
     };
   });
   return result;


### PR DESCRIPTION
We were not including the deprecation reason inside of the type construction of merge schema. This PR fixes and tests the issue. Ran into this while working on the gateway github schema checks. 🎉 🐶 🥘 

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

