### PR TITLE
"a userId" vs. "an userId"

### DIFF
--- a/docs/source/schema-delegation.md
+++ b/docs/source/schema-delegation.md
@@ -159,7 +159,7 @@ type Booking {
 }
 ```
 
-If we delegate at `User.bookings` to `Query.bookingsByUser`, we want to preserve the `limit` argument and add an `userId` argument by using the `User.id`. So the resolver would look like the following:
+If we delegate at `User.bookings` to `Query.bookingsByUser`, we want to preserve the `limit` argument and add a `userId` argument by using the `User.id`. So the resolver would look like the following:
 
 ```js
 const resolvers = {


### PR DESCRIPTION
_If the sound of the first letter is like Y then we use a, like a user, because u in user is like y. Otherwise, we use an, like an apple, an orange... ... For example, the word "user" is pronounced "yoozer" (the initial "y" sound acts as a consonant) so it must be preceded by an "a," not an "an."_ - https://www.quora.com/Is-it-an-user-or-a-user
https://www.quickanddirtytips.com/education/grammar/a-versus-an

