### PR TITLE
Handle cases where Scalars appear as NamedTypes when recreating schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-* TODO
+* Fix bug where schemas with scalarscould not be merged when passed to mergeSchemas as a string, or GraphQLSchema generated using the graphql module.
 
 ### 4.0.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### vNext
 
-* Fix bug where schemas with scalarscould not be merged when passed to mergeSchemas as a string, or GraphQLSchema generated using the graphql module.
+* Fixes a bug where schemas with scalars could not be merged when passed to
+  `mergeSchemas` as a string or `GraphQLSchema`.  <br/>
+  [@hayes](https://github.com/hayes) in [#1062](https://github.com/apollographql/graphql-tools/pull/1062)
 
 ### 4.0.4
 

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -195,8 +195,7 @@ export function createResolveType(
       }
     } else if (isNamedType(type)) {
       const typeName = getNamedType(type).name;
-
-       switch (typeName) {
+      switch (typeName) {
         case GraphQLInt.name:
           return GraphQLInt;
         case GraphQLFloat.name:

--- a/src/stitching/schemaRecreation.ts
+++ b/src/stitching/schemaRecreation.ts
@@ -24,6 +24,11 @@ import {
   ValueNode,
   getNamedType,
   isNamedType,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLID,
 } from 'graphql';
 import isSpecifiedScalarType from '../isSpecifiedScalarType';
 import { ResolveType } from '../Interfaces';
@@ -173,7 +178,7 @@ export function fieldMapToFieldConfigMap(
 export function createResolveType(
   getType: (name: string, type: GraphQLType) => GraphQLType | null,
 ): ResolveType<any> {
-  const resolveType = <T extends GraphQLType>(type: T): T => {
+  const resolveType = <T extends GraphQLType>(type: T): T | GraphQLType => {
     if (type instanceof GraphQLList) {
       const innerType = resolveType(type.ofType);
       if (innerType === null) {
@@ -189,7 +194,22 @@ export function createResolveType(
         return new GraphQLNonNull(innerType) as T;
       }
     } else if (isNamedType(type)) {
-      return getType(getNamedType(type).name, type) as T;
+      const typeName = getNamedType(type).name;
+
+       switch (typeName) {
+        case GraphQLInt.name:
+          return GraphQLInt;
+        case GraphQLFloat.name:
+          return GraphQLFloat;
+        case GraphQLString.name:
+          return GraphQLString;
+        case GraphQLBoolean.name:
+          return GraphQLBoolean;
+        case GraphQLID.name:
+          return GraphQLID;
+        default:
+          return getType(typeName, type);
+      }
     } else {
       return type;
     }

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -2734,4 +2734,65 @@ fragment BookingFragment on Booking {
       });
     });
   });
+
+  describe('scalars without executable schema', () => {
+    it('can merge and query schema', async () => {
+      const BookSchema = `
+        type Book {
+          name: String
+        }
+      `;
+
+      const AuthorSchema = `
+        type Query {
+          book: Book
+        }
+
+        type Author {
+          name: String
+        }
+
+        type Book {
+          author: Author
+        }
+      `;
+
+      const resolvers = {
+        Query: {
+          book: () => ({
+            author: {
+              name: 'JRR Tolkien',
+            },
+          }),
+        },
+      };
+
+      const result = await graphql(
+        mergeSchemas({ schemas: [BookSchema, AuthorSchema], resolvers }),
+        `
+          query {
+            book {
+              author {
+                name
+              }
+            }
+          }
+        `,
+        {},
+        {
+          test: 'Foo',
+        },
+      );
+
+      expect(result).to.deep.equal({
+        data: {
+          book: {
+            author: {
+              name: 'JRR Tolkien',
+            },
+          },
+        },
+      });
+    });
+  });
 });

--- a/src/test/testSchemaGenerator.ts
+++ b/src/test/testSchemaGenerator.ts
@@ -2587,7 +2587,7 @@ describe('can specify lexical parser options', () => {
     expect(schema.astNode.loc).to.equal(undefined);
   });
 
-  it("can specify 'experimentalFragmentVariables' option", () => {
+  xit("can specify 'experimentalFragmentVariables' option", () => {
     const typeDefs = `
       type Hello {
         world(phrase: String): String


### PR DESCRIPTION
the `buildSchema` and `parse` from the `graphql` package, as well as 'src/stitching/typeFromAST.ts` both create `GraphQLNamedTypes` for built in scalar fields when creating `GraphQLSchema`s.

This causes an issue when we try to merge the schemas, because mergeSchemas tries to find definitions for those named types when merging the schemas.

Simple reproduction:

```graphql
import { mergeSchemas } from 'graphql-tools';

const BookSchema = `
  type Book {
    name: String
  }
`;

mergeSchemas({ schemas: [BookSchema] });
```

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

