### PR TITLE
Adding override query resolvers flag.

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -167,6 +167,7 @@ export interface IMockOptions {
   schema: GraphQLSchema;
   mocks?: IMocks;
   preserveResolvers?: boolean;
+  overrideQueryResolvers?: boolean;
 }
 
 export interface IMockServer {

--- a/src/test/testMocking.ts
+++ b/src/test/testMocking.ts
@@ -1467,6 +1467,57 @@ describe('Mock', () => {
     });
   });
 
+  it('should override only specific resolver with mock', () => {
+    const typeDefs = `
+      type Query {
+        hello: String
+        bar: String
+      }
+    `;
+
+    const resolvers = {
+      Query: {
+        hello: () => 'Hello world!',
+        bar: () => 'FooBar'
+      }
+    };
+
+    const mocks = {
+      String: () => 'Foo',
+      Query: () => ({
+        hello: () => '[Mock] Hello world!'
+      })
+    };
+
+    const query = `
+    {
+      hello
+      bar
+    }
+    `;
+
+    const schema = makeExecutableSchema({
+      typeDefs,
+      resolvers,
+    });
+    addMockFunctionsToSchema({
+      schema,
+      mocks: mocks,
+      preserveResolvers: true,
+      overrideQueryResolvers: true
+    });
+
+    const expected = {
+      data: {
+        hello: '[Mock] Hello world!',
+        bar: 'FooBar'
+      },
+    };
+    return graphql(schema, query).then(res => {
+      expect(res).to.deep.equal(expected);
+    });
+  });
+
   // TODO add a test that checks that even when merging defaults, lists invoke
   // the function for every object, not just once per list.
 


### PR DESCRIPTION
This flag should work with preserveResolvers to override only schema query/mutation specific resolvers with mock functions.

relates to #1068 (check comment https://github.com/apollographql/graphql-tools/issues/1068#issuecomment-480552402)
