### PR TITLE
Fix tests

### DIFF
--- a/src/test/testMakeRemoteExecutableSchema.ts
+++ b/src/test/testMakeRemoteExecutableSchema.ts
@@ -32,15 +32,15 @@ describe('remote subscriptions', () => {
     `);
 
     let notificationCnt = 0;
-    subscribe(schema, subscription).then(results =>
+    subscribe(schema, subscription).then(results => {
       forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
         expect(result).to.have.property('data');
         expect(result.data).to.deep.equal(mockNotification);
         !notificationCnt++ ? done() : null;
-      }),
-    );
-
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+      });
+    }).then(() => {
+      subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+    });
   });
 
   it('should work without triggering multiple times per notification', done => {
@@ -59,27 +59,29 @@ describe('remote subscriptions', () => {
     `);
 
     let notificationCnt = 0;
-    subscribe(schema, subscription).then(results =>
+    const sub1 = subscribe(schema, subscription).then(results => {
       forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
         expect(result).to.have.property('data');
         expect(result.data).to.deep.equal(mockNotification);
         notificationCnt++;
-      }),
-    );
+      })
+    });
 
-    subscribe(schema, subscription).then(results =>
+    const sub2 = subscribe(schema, subscription).then(results => {
       forAwaitEach(results as AsyncIterable<ExecutionResult>, (result: ExecutionResult) => {
         expect(result).to.have.property('data');
         expect(result.data).to.deep.equal(mockNotification);
-      }),
-    );
+      });
+    });
 
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+    Promise.all([sub1, sub2]).then(() => {
+      subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+      subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
 
-    setTimeout(() => {
-      expect(notificationCnt).to.eq(2);
-      done();
-    }, 0);
+      setTimeout(() => {
+        expect(notificationCnt).to.eq(2);
+        done();
+      }, 0);
+    });
   });
 });

--- a/src/test/testMakeRemoteExecutableSchema.ts
+++ b/src/test/testMakeRemoteExecutableSchema.ts
@@ -64,7 +64,7 @@ describe('remote subscriptions', () => {
         expect(result).to.have.property('data');
         expect(result.data).to.deep.equal(mockNotification);
         notificationCnt++;
-      })
+      });
     });
 
     const sub2 = subscribe(schema, subscription).then(results => {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -736,10 +736,9 @@ bookingById(id: "b1") {
                 !notificationCnt++ ? done() : null;
               },
             ).catch(done);
-          })
-          .catch(done);
-
-        subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+          }).then(() => {
+            subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+          }).catch(done);
       });
 
       it('subscription errors are working correctly in merged schema', done => {
@@ -793,10 +792,9 @@ bookingById(id: "b1") {
                 !notificationCnt++ ? done() : null;
               },
             ).catch(done);
-          })
-          .catch(done);
-
-        subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+          }).then(() => {
+            subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+          }).catch(done);
       });
 
       it('links in queries', async () => {

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -119,11 +119,11 @@ describe('Resolve', () => {
                 done(new Error('Too many subscription fired'));
               },
             ).catch(done);
-          })
-          .catch(done);
+          }).then(() => {
+            pubsub.publish('printRootChannel', { printRoot: subscriptionRoot });
+          }).catch(done);
       });
 
-      pubsub.publish('printRootChannel', { printRoot: subscriptionRoot });
 
       firstSubsTriggered
         .then(() =>


### PR DESCRIPTION
graphql 1.1.0 only adds listeners after first call to next(), see https://github.com/apollographql/graphql-subscriptions/pull/148.

- [x] **NA:** If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] **NA**: Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

