### PR TITLE
Use Maps inside ReplaceFieldWithFragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   [@hayes](https://github.com/hayes) in [#1062](https://github.com/apollographql/graphql-tools/pull/1062)
 * Make `mergeSchemas` optionally merge directive definitions.  <br/>
   [@freiksenet](https://github.com/freiksenet) in [#1003](https://github.com/apollographql/graphql-tools/pull/1003)
+* Enable `constructor` and other JS built-in field names in stitched schemas <br />
+  [@gnidan](https://github.com/gnidan) in
+  [#1108](https://github.com/apollographql/graphql-tools/pull/1108)
 
 ### 4.0.4
 


### PR DESCRIPTION
This should fix #1107.

Instead of regular JS objects. This should allow using type names /
field names that collide with JS builtins, e.g. `constructor`


TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.