### PR TITLE
Issue #1127: Fix unexpected colon in two examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   [@hayes](https://github.com/hayes) in [#1062](https://github.com/apollographql/graphql-tools/pull/1062)
 * Make `mergeSchemas` optionally merge directive definitions.  <br/>
   [@freiksenet](https://github.com/freiksenet) in [#1003](https://github.com/apollographql/graphql-tools/pull/1003)
+* Fixes `node-fetch` examples unexpected colon  <br/>
+  [@mikaelkundert](https://github.com/mikaelkundert/) in [#1128](https://github.com/apollographql/graphql-tools/pull/1128)
 
 ### 4.0.4
 

--- a/docs/source/remote-schemas.md
+++ b/docs/source/remote-schemas.md
@@ -161,7 +161,7 @@ Basic usage
 
 ```js
 import fetch from 'node-fetch';
-import { print } from 'graphql':
+import { print } from 'graphql';
 
 const fetcher = async ({ query: queryDocument, variables, operationName, context }) => {
   const query = print(queryDocument);
@@ -188,7 +188,7 @@ Authentication headers from context
 
 ```js
 import fetch from 'node-fetch';
-import { print } from 'graphql':
+import { print } from 'graphql';
 
 const fetcher = async ({ query: queryDocument, variables, operationName, context }) => {
   const query = print(queryDocument);


### PR DESCRIPTION
On [Remote schemas](https://www.apollographql.com/docs/graphql-tools/remote-schemas) docs we have an example for using `node-fetch`:

```js
import fetch from 'node-fetch';
import { print } from 'graphql':

const fetcher = async ({ query: queryDocument, variables, operationName, context }) => {
  const query = print(queryDocument);
  const fetchResult = await fetch('http://api.githunt.com/graphql', {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
    },
    body: JSON.stringify({ query, variables, operationName })
  });
  return fetchResult.json();
};

export default async () => {
  const schema = makeRemoteExecutableSchema({
    schema: await introspectSchema(fetcher),
    fetcher,
  });
  return schema
}
```

Line 2 ends with `:` and doesn't work.

This pull request replaces it with semicolon.