### PR TITLE
Pass through all possible stitching errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   [@hayes](https://github.com/hayes) in [#1062](https://github.com/apollographql/graphql-tools/pull/1062)
 * Make `mergeSchemas` optionally merge directive definitions.  <br/>
   [@freiksenet](https://github.com/freiksenet) in [#1003](https://github.com/apollographql/graphql-tools/pull/1003)
+* Pass through all possible errors. <br/>
+  [PR #1147](https://github.com/apollographql/graphql-tools/pull/1147) closes issues [#743](https://github.com/apollographql/graphql-tools/issues/743), [#1037](https://github.com/apollographql/graphql-tools/issues/1037), [#1046](https://github.com/apollographql/graphql-tools/issues/1046)
 
 ### 4.0.4
 

--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -3,7 +3,7 @@ title: Schema stitching (deprecated)
 description: Combining multiple GraphQL APIs into one
 ---
 
-> **Deprecated:** Federation is our replacement for schema stitching that enables developers to declaratively compose a distributed graph. Learn why in our [blog post](https://blog.apollographql.com/apollo-federation-f260cf525d21) and [how to migrate](https://www.apollographql.com/docs/apollo-server/federation/migrating-from-stitching/) in the federation guide.
+> **Deprecated:** Federation is our replacement for schema stitching that enables developers to declaratively compose a distributed graph. Learn why in our [blog post](https://blog.apollographql.com/apollo-federation-f260cf525d21) and [how to migrate](/docs/apollo-server/federation/migrating-from-stitching/) in the federation guide.
 
 Schema stitching is the process of creating a single GraphQL schema from multiple underlying GraphQL APIs.
 

--- a/docs/source/schema-stitching.md
+++ b/docs/source/schema-stitching.md
@@ -3,7 +3,7 @@ title: Schema stitching (deprecated)
 description: Combining multiple GraphQL APIs into one
 ---
 
-> **Deprecated:** Federation is our replacement for schema stitching that enables developers to declaratively compose a distributed graph. Learn why in our [blog post](https://blog.apollographql.com/apollo-federation-f260cf525d21) and [how to migrate](/docs/apollo-server/federation/migrating-from-stitching/) in the federation guide.
+> **Deprecated:** Federation is our replacement for schema stitching that enables developers to declaratively compose a distributed graph. Learn why in our [blog post](https://blog.apollographql.com/apollo-federation-f260cf525d21) and [how to migrate](https://www.apollographql.com/docs/apollo-server/federation/migrating-from-stitching/) in the federation guide.
 
 Schema stitching is the process of creating a single GraphQL schema from multiple underlying GraphQL APIs.
 

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -407,7 +407,11 @@ const propertyResolvers: IResolvers = {
 
   Property: {
     error() {
-      throw new Error('Property.error error');
+      const error = new Error('Property.error error');
+      (error as any).extensions = {
+        code: 'SOME_CUSTOM_CODE',
+      };
+      throw error;
     },
   },
 };


### PR DESCRIPTION
This PR aims to solve the same issues as #1074 (i.e., #743, #1037, #1046, apollographql/apollo-server#1582).

It does so by:

- making sure to not use object spread notation with GraphQL error objects, as these are not plain objects.
- using a new relocatedError function based on [locatedError](https://github.com/graphql/graphql-js/blob/master/src/error/locatedError.js) to change a GraphQL error path.
- remove distinction between OWN and CHILDREN errors within error annotation; when null, both must be thrown, as otherwise children errors will never be thrown.

TODO (finished)

- [X] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass
- [X] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.