### PR TITLE
Fixed interfaces & unions when RenameTypes' renamer() returned undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### vNEXT
+* Fixes a bug where interfaces and unions wouldn't correctly resolve if RenameTypes' renamer() function
+  returned `undefined`<br/>
+  [@ftatzky](https://github.com/ftatzky) in [#1170](https://github.com/apollographql/graphql-tools/pull/1170)
+
 ### 4.0.5
 
 * Fixes a bug where schemas with scalars could not be merged when passed to

--- a/src/test/testTransforms.ts
+++ b/src/test/testTransforms.ts
@@ -147,6 +147,75 @@ describe('transforms', () => {
     });
   });
 
+  describe('interfaces (and unions) when renamer() returns undefined', () => {
+    let schema: GraphQLSchema;
+    before(() => {
+      const transforms = [
+        new RenameTypes((name: string) => undefined),
+      ];
+      schema = transformSchema(propertySchema, transforms);
+    });
+    it('should work', async () => {
+      const result = await graphql(
+        schema,
+        `
+          query {
+            interfaceTest(kind: ONE) {
+              ... on TestInterface {
+                testString
+              }
+            }
+
+            test1: unionTest(output: "Interface") {
+              ... on TestInterface {
+                kind
+                testString
+              }
+              ... on TestImpl1 {
+                foo
+              }
+              ... on UnionImpl {
+                someField
+              }
+            }
+
+            test2: unionTest(output: "OtherStuff") {
+              ... on TestInterface {
+                kind
+                testString
+              }
+              ... on TestImpl1 {
+                foo
+              }
+              ... on UnionImpl {
+                someField
+              }
+            }
+          }
+        `,
+        {},
+        {},
+        {},
+      );
+
+      expect(result).to.deep.equal({
+        data: {
+          interfaceTest: {
+            testString: 'test',
+          },
+          test1: {
+            kind: 'ONE',
+            testString: 'test',
+            foo: 'foo',
+          },
+          test2: {
+            someField: 'Bar',
+          },
+        },
+      });
+    });
+  });
+
   describe('filter to schema', () => {
     let filter: FilterToSchema;
     before(() => {

--- a/src/transforms/RenameTypes.ts
+++ b/src/transforms/RenameTypes.ts
@@ -91,7 +91,8 @@ export default class RenameTypes implements Transform {
 
   private renameTypes(value: any, name?: string) {
     if (name === '__typename') {
-      return this.renamer(value);
+      const renamed = this.renamer(value);
+      return typeof renamed !== 'undefined' ? renamed : value;
     }
 
     if (value && typeof value === 'object') {


### PR DESCRIPTION
According to your [docs](https://www.apollographql.com/docs/apollo-server/features/schema-transforms/#modifying-types) types should be left unchanged if renamer() returns undefined. However right now interfaces and unions won't be correctly resolved, because type information is missing during the transformResult() step. This PR fixes that.