### PR TITLE
Feat/stiched errors extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### vNext
+
+* Make remote schemas pass error extensions through. <br/>
+[@carmelid](https://github.com/carmelid) in [#1179](https://github.com/apollographql/graphql-tools/pull/1179)
+
 ### 4.0.5
 
 * Fixes a bug where schemas with scalars could not be merged when passed to

--- a/src/stitching/defaultMergedResolver.ts
+++ b/src/stitching/defaultMergedResolver.ts
@@ -1,5 +1,4 @@
-import { GraphQLFieldResolver, responsePathAsArray } from 'graphql';
-import { locatedError } from 'graphql/error';
+import { GraphQLError, GraphQLFieldResolver, responsePathAsArray } from 'graphql';
 import { getErrorsFromParent, annotateWithChildrenErrors } from './errors';
 import { getResponseKeyFromInfo } from './getResponseKeyFromInfo';
 
@@ -15,7 +14,15 @@ const defaultMergedResolver: GraphQLFieldResolver<any, any> = (parent, args, con
   const errorResult = getErrorsFromParent(parent, responseKey);
 
   if (errorResult.kind === 'OWN') {
-    throw locatedError(new Error(errorResult.error.message), info.fieldNodes, responsePathAsArray(info.path));
+    throw new GraphQLError(
+      errorResult.error.message,
+      info.fieldNodes,
+      undefined,
+      undefined,
+      responsePathAsArray(info.path),
+      undefined,
+      errorResult.error.extensions,
+    );
   }
 
   let result = parent[responseKey];

--- a/src/test/testMakeRemoteExecutableSchema.ts
+++ b/src/test/testMakeRemoteExecutableSchema.ts
@@ -41,7 +41,7 @@ describe('remote subscriptions', () => {
       })
     );
 
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+    setTimeout(() => subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification), 0);
   });
 
   it('should work without triggering multiple times per notification', done => {
@@ -75,13 +75,16 @@ describe('remote subscriptions', () => {
       })
     );
 
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
-    subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
-
     setTimeout(() => {
-      expect(notificationCnt).to.eq(2);
-      done();
+      subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+      subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+
+      setTimeout(() => {
+        expect(notificationCnt).to.eq(2);
+        done();
+      }, 0);
     }, 0);
+
   });
 });
 

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -739,7 +739,7 @@ bookingById(id: "b1") {
           })
           .catch(done);
 
-        subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+        setTimeout(() => subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification), 0);
       });
 
       it('subscription errors are working correctly in merged schema', done => {
@@ -796,7 +796,7 @@ bookingById(id: "b1") {
           })
           .catch(done);
 
-        subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification);
+        setTimeout( () => subscriptionPubSub.publish(subscriptionPubSubTrigger, mockNotification), 0);
       });
 
       it('links in queries', async () => {

--- a/src/test/testMergeSchemas.ts
+++ b/src/test/testMergeSchemas.ts
@@ -2197,10 +2197,12 @@ fragment BookingFragment on Booking {
               propertyById(id: "p1") {
                 error
                 errorAlias: error
+                errorWithExtensions
                 bookings {
                   id
                   error
                   bookingErrorAlias: error
+                  errorWithExtensions
                 }
               }
             }
@@ -2212,16 +2214,19 @@ fragment BookingFragment on Booking {
             propertyById: {
               bookings: [
                 {
+                  errorWithExtensions: null,
                   bookingErrorAlias: null,
                   error: null,
                   id: 'b1',
                 },
                 {
+                  errorWithExtensions: null,
                   bookingErrorAlias: null,
                   error: null,
                   id: 'b2',
                 },
                 {
+                  errorWithExtensions: null,
                   bookingErrorAlias: null,
                   error: null,
                   id: 'b3',
@@ -2229,6 +2234,7 @@ fragment BookingFragment on Booking {
               ],
               error: null,
               errorAlias: null,
+              errorWithExtensions: null,
             },
           },
           errors: [
@@ -2253,10 +2259,23 @@ fragment BookingFragment on Booking {
               path: ['propertyById', 'errorAlias'],
             },
             {
+              extensions: {
+                code: 'NOT_FOUND',
+              },
+              locations: [
+                {
+                  column: 17,
+                  line: 6,
+                },
+              ],
+              message: 'Property.error error',
+              path: ['propertyById', 'errorWithExtensions'],
+            },
+            {
               locations: [
                 {
                   column: 19,
-                  line: 8,
+                  line: 9,
                 },
               ],
               message: 'Booking.error error',
@@ -2266,17 +2285,35 @@ fragment BookingFragment on Booking {
               locations: [
                 {
                   column: 19,
-                  line: 9,
+                  line: 10,
                 },
               ],
               message: 'Booking.error error',
               path: ['propertyById', 'bookings', 0, 'bookingErrorAlias'],
             },
             {
+              extensions: {
+                someExtension: true,
+              },
               locations: [
                 {
                   column: 19,
-                  line: 8,
+                  line: 11,
+                }
+              ],
+              message: 'Booking.errorWithExtensions error',
+              path: [
+                'propertyById',
+                'bookings',
+                0,
+                'errorWithExtensions',
+              ],
+            },
+            {
+              locations: [
+                {
+                  column: 19,
+                  line: 9,
                 },
               ],
               message: 'Booking.error error',
@@ -2286,17 +2323,35 @@ fragment BookingFragment on Booking {
               locations: [
                 {
                   column: 19,
-                  line: 9,
+                  line: 10,
                 },
               ],
               message: 'Booking.error error',
               path: ['propertyById', 'bookings', 1, 'bookingErrorAlias'],
             },
             {
+              extensions: {
+                someExtension: true,
+              },
               locations: [
                 {
                   column: 19,
-                  line: 8,
+                  line: 11,
+                }
+              ],
+              message: 'Booking.errorWithExtensions error',
+              path: [
+                'propertyById',
+                'bookings',
+                1,
+                'errorWithExtensions',
+              ],
+            },
+            {
+              locations: [
+                {
+                  column: 19,
+                  line: 9,
                 },
               ],
               message: 'Booking.error error',
@@ -2306,11 +2361,29 @@ fragment BookingFragment on Booking {
               locations: [
                 {
                   column: 19,
-                  line: 9,
+                  line: 10,
                 },
               ],
               message: 'Booking.error error',
               path: ['propertyById', 'bookings', 2, 'bookingErrorAlias'],
+            },
+            {
+              extensions: {
+                someExtension: true,
+              },
+              locations: [
+                {
+                  column: 19,
+                  line: 11,
+                }
+              ],
+              message: 'Booking.errorWithExtensions error',
+              path: [
+                'propertyById',
+                'bookings',
+                2,
+                'errorWithExtensions',
+              ],
             },
           ],
         });

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -123,7 +123,7 @@ describe('Resolve', () => {
           .catch(done);
       });
 
-      pubsub.publish('printRootChannel', { printRoot: subscriptionRoot });
+      setTimeout(() => pubsub.publish('printRootChannel', { printRoot: subscriptionRoot }), 0);
 
       firstSubsTriggered
         .then(() =>

--- a/src/test/testingSchemas.ts
+++ b/src/test/testingSchemas.ts
@@ -172,6 +172,14 @@ export const sampleData: {
   },
 };
 
+class ErrorWithExtensions extends Error {
+  public extensions: {[key: string]: any};
+  constructor(message: string, extensions: {[key: string]: any}) {
+    super(message);
+    this.extensions = extensions;
+  }
+}
+
 function values<T>(o: { [s: string]: T }): T[] {
   return Object.keys(o).map(k => o[k]);
 }
@@ -249,6 +257,7 @@ const propertyAddressTypeDef = `
     location: Location
     address: Address
     error: String
+    errorWithExtensions: String
   }
 `;
 
@@ -409,6 +418,9 @@ const propertyResolvers: IResolvers = {
     error() {
       throw new Error('Property.error error');
     },
+    errorWithExtensions() {
+      throw new ErrorWithExtensions('Property.error error', { code: 'NOT_FOUND' });
+    },
   },
 };
 
@@ -488,6 +500,7 @@ const bookingRootTypeDefs = `
     endTime: String!
     error: String
     errorNonNull: String!
+    errorWithExtensions: String
   }
 
   interface Person {
@@ -597,6 +610,9 @@ const bookingResolvers: IResolvers = {
     errorNonNull() {
       throw new Error('Booking.errorNoNull error');
     },
+    errorWithExtensions() {
+      throw new ErrorWithExtensions('Booking.errorWithExtensions error', { someExtension: true });
+    }
   },
 
   Customer: {


### PR DESCRIPTION
By using the `GraphQLError` constructor directly we are able to pass extensions through, as opposed to when using `locatedError` which does not produce a `GraphQLError` with extensions. This means that remote custom extensions can be passed through and not get lost along the way.

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes) (small change IMO)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

