### PR TITLE
Rename `typeResolvers` to `resolvers`

### DIFF
--- a/docs/source/mocking.md
+++ b/docs/source/mocking.md
@@ -175,7 +175,7 @@ type ProductList implements List {
 }
 `
 
-const typeResolvers = {
+const resolvers = {
   List: {
     __resolveType(data) {
       return data.typename // typename property must be set by your mock functions
@@ -185,7 +185,7 @@ const typeResolvers = {
 
 const schema = makeExecutableSchema({
   typeDefs,
-  typeResolvers
+  resolvers
 })
 
 addMockFunctionsToSchema({


### PR DESCRIPTION
I am afraid this example code could mislead because the `makeExecutableSchema` function doesn't have a parameter named `typeResolvers` according to [the API](https://www.apollographql.com/docs/graphql-tools/generate-schema/#makeexecutableschemaoptions).
I think this variable should be renamed to `resolvers` so that the code works as intended.