### PR TITLE
[docs] Add undocumented method arguments

### DIFF
--- a/docs/source/schema-directives.md
+++ b/docs/source/schema-directives.md
@@ -63,14 +63,14 @@ To implement a schema directive using `SchemaDirectiveVisitor`, simply create a 
 * `visitSchema(schema: GraphQLSchema)`
 * `visitScalar(scalar: GraphQLScalarType)`
 * `visitObject(object: GraphQLObjectType)`
-* `visitFieldDefinition(field: GraphQLField<any, any>)`
-* `visitArgumentDefinition(argument: GraphQLArgument)`
+* `visitFieldDefinition(field: GraphQLField<any, any>, details: { objectType: GraphQLObjectType | GraphQLInterfaceType })`
+* `visitArgumentDefinition(argument: GraphQLArgument, objectType: GraphQLObjectType | GraphQLInterfaceType })`
 * `visitInterface(iface: GraphQLInterfaceType)`
 * `visitUnion(union: GraphQLUnionType)`
 * `visitEnum(type: GraphQLEnumType)`
-* `visitEnumValue(value: GraphQLEnumValue)`
+* `visitEnumValue(value: GraphQLEnumValue, details: { enumType: GraphQLEnumType })`
 * `visitInputObject(object: GraphQLInputObjectType)`
-* `visitInputFieldDefinition(field: GraphQLInputField)`
+* `visitInputFieldDefinition(field: GraphQLInputField, details: { objectType: GraphQLInputObjectType })`
 
 By overriding methods like `visitObject`, a subclass of `SchemaDirectiveVisitor` expresses interest in certain schema types such as `GraphQLObjectType` (the first parameter type of `visitObject`).
 


### PR DESCRIPTION
Several of SchemaDirectiveVisitor's methods have arguments that don't appear to be in any documentation ([source](https://github.com/apollographql/graphql-tools/blob/c8d6e55cb6a23af412d3bc650bd79d5cf94c4317/src/schemaVisitor.ts#L90)). The same issue also applies to the signatures given in VS Code's Intellisense, but I'm not familiar enough to find the appropriate place to fix that.

Cheers.

