### PR TITLE
Use getIntrospectionQuery instead of deprecated introspectionQuery constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### vNext
+
+* Use `getIntrospectionQuery` instead of deprecated `introspectionQuery` constant from graphql-js
+  [@derek-miller](https://github.com/derek-miller) in [#1228](https://github.com/apollographql/graphql-tools/pull/1228)
+
 ### 4.0.5
 
 * Fixes a bug where schemas with scalars could not be merged when passed to

--- a/src/stitching/introspectSchema.ts
+++ b/src/stitching/introspectSchema.ts
@@ -1,10 +1,11 @@
 import { GraphQLSchema, DocumentNode } from 'graphql';
-import { introspectionQuery, buildClientSchema, parse } from 'graphql';
+import { buildClientSchema, parse } from 'graphql';
+import { getIntrospectionQuery } from 'graphql/utilities';
 import { ApolloLink } from 'apollo-link';
 import { Fetcher } from './makeRemoteExecutableSchema';
 import linkToFetcher from './linkToFetcher';
 
-const parsedIntrospectionQuery: DocumentNode = parse(introspectionQuery);
+const parsedIntrospectionQuery: DocumentNode = parse(getIntrospectionQuery());
 
 export default async function introspectSchema(
   fetcher: ApolloLink | Fetcher,


### PR DESCRIPTION
`introspectionQuery` is being removed in v15 of graphql-js.