### PR TITLE
Add ESM build for tree-shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 coverage
 npm-debug.log
 dist
+es
 *.tgz
 .DS_Store
 package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,11 @@
 !dist/stitching/*
 !dist/transforms/*
 !dist/generate/*
+!es/
+!es/*
+!es/stitching/*
+!es/transforms/*
+!es/generate/*
 !package.json
 !*.md
 !*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+### vNEXT
+
+* Add ESM build for tree-shaking
+  [@sheepsteak](https://github.com/sheepsteak) in [#1238](https://github.com/apollographql/graphql-tools/pull/1238)
+
 ### 4.0.6
 
 * Use `getIntrospectionQuery` instead of deprecated `introspectionQuery` constant from graphql-js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.6",
   "description": "Useful tools to create and manipulate GraphQL schemas.",
   "main": "dist/index.js",
+  "module": "es/index.js",
   "typings": "dist/index.d.ts",
   "typescript": {
     "definition": "dist/index.d.ts"
@@ -12,7 +13,9 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "compile": "npx tsc",
+    "compile": "npm run compile:es5 && npm run compile:modules",
+    "compile:es5": "tsc",
+    "compile:modules": "tsc --outDir es --module esnext",
     "typings": "typings install",
     "pretest": "npm run clean && npm run compile",
     "test": "npm run testonly --",

--- a/src/test/testDirectives.ts
+++ b/src/test/testDirectives.ts
@@ -30,7 +30,7 @@ import {
   GraphQLInt,
 } from 'graphql';
 
-import formatDate = require('dateformat');
+import formatDate from 'dateformat';
 
 const typeDefs = `
 directive @schemaDirective(role: String) on SCHEMA

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "outDir": "./dist",
     "removeComments": false,
     "noImplicitUseStrict": true,
+    "esModuleInterop": true
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "es"]
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

Prior discussion of this in #343 and #344.

- [x] Produce build with ESM modules in it into `es` folder
- [x] Fix `require` in tests by using `esModuleInterop` into `tsconfig.json`
- [x] Add `module` field so that tooling can find the ESM build

Once merged the ESM build will just get done alongside the ES5 build. I did `npm pack` to make sure the `es` folder will get included.

I linked this version into an AWS Lambda function where I'm only importing `makeExecutableSchema` and nothing else from `graphql-tools`. I saw a __100KiB reduction__ in a production build size. 
