### PR TITLE
compat: minimal changes to support graphql@15 within Apollo Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### vNEXT
+
+* Filter `extensions` prior to passing them to `buildASTSchema`, in an effort to provide minimum compatibilty for `graphql@14`-compatible schemas with the upcoming `graphql@15` release. This PR does not, however, bring support for newer `graphql@15` features like interfaces implementing interfaces. [#1284](https://github.com/apollographql/graphql-tools/pull/1284)
+
 ### 4.0.6
 
 * Use `getIntrospectionQuery` instead of deprecated `introspectionQuery` constant from graphql-js

--- a/src/generate/buildSchemaFromTypeDefinitions.ts
+++ b/src/generate/buildSchemaFromTypeDefinitions.ts
@@ -12,6 +12,7 @@ import {
   concatenateTypeDefs,
   SchemaError,
 } from '.';
+import filterExtensionDefinitions from './filterExtensionDefinitions';
 
 function buildSchemaFromTypeDefinitions(
   typeDefinitions: ITypeDefinitions,
@@ -38,10 +39,11 @@ function buildSchemaFromTypeDefinitions(
   }
 
   const backcompatOptions = { commentDescriptions: true };
+  const typesAst = filterExtensionDefinitions(astDocument);
 
   // TODO fix types https://github.com/apollographql/graphql-tools/issues/542
   let schema: GraphQLSchema = (buildASTSchema as any)(
-    astDocument,
+    typesAst,
     backcompatOptions,
   );
 

--- a/src/generate/filterExtensionDefinitions.ts
+++ b/src/generate/filterExtensionDefinitions.ts
@@ -1,0 +1,19 @@
+import { DocumentNode, DefinitionNode, Kind } from 'graphql';
+
+export default function filterExtensionDefinitions(ast: DocumentNode) {
+  const extensionDefs = ast.definitions.filter(
+    (def: DefinitionNode) =>
+      def.kind !== Kind.OBJECT_TYPE_EXTENSION &&
+      def.kind !== Kind.INTERFACE_TYPE_EXTENSION &&
+      def.kind !== Kind.INPUT_OBJECT_TYPE_EXTENSION &&
+      def.kind !== Kind.UNION_TYPE_EXTENSION &&
+      def.kind !== Kind.ENUM_TYPE_EXTENSION &&
+      def.kind !== Kind.SCALAR_TYPE_EXTENSION &&
+      def.kind !== Kind.SCHEMA_EXTENSION,
+  );
+
+  return {
+    ...ast,
+    definitions: extensionDefs,
+  };
+}

--- a/src/stitching/makeRemoteExecutableSchema.ts
+++ b/src/stitching/makeRemoteExecutableSchema.ts
@@ -31,7 +31,6 @@ import resolveParentFromTypename from './resolveFromParentTypename';
 import defaultMergedResolver from './defaultMergedResolver';
 import { checkResultAndHandleErrors } from './errors';
 import { observableToAsyncIterable } from './observableToAsyncIterable';
-import { Options as PrintSchemaOptions } from 'graphql/utilities/schemaPrinter';
 
 export type ResolverFn = (
   rootValue?: any,
@@ -48,6 +47,27 @@ export type FetcherOperation = {
   variables?: { [key: string]: any };
   context?: { [key: string]: any };
 };
+
+/**
+ * This type has been copied inline from its source on `@types/graphql`:
+ *
+ * https://git.io/Jv8NX
+ *
+ * Previously, it was imported from `graphql/utilities/schemaPrinter`, however
+ * that module has been removed in `graphql@15`.  Furthermore, the sole property
+ * on this type is due to be deprecated in `graphql@16`.
+ */
+interface PrintSchemaOptions {
+  /**
+   * Descriptions are defined as preceding string literals, however an older
+   * experimental version of the SDL supported preceding comments as
+   * descriptions. Set to true to enable this deprecated behavior.
+   * This option is provided to ease adoption and will be removed in v16.
+   *
+   * Default: false
+   */
+  commentDescriptions?: boolean;
+}
 
 export default function makeRemoteExecutableSchema({
   schema,

--- a/src/stitching/observableToAsyncIterable.ts
+++ b/src/stitching/observableToAsyncIterable.ts
@@ -2,7 +2,11 @@ import { Observable } from 'apollo-link';
 import { $$asyncIterator } from 'iterall';
 type Callback = (value?: any) => any;
 
-export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIterator<T> {
+export function observableToAsyncIterable<T>(
+  observable: Observable<T>
+): AsyncIterator<T> & {
+  [$$asyncIterator]: () => AsyncIterator<T>;
+} {
   const pullQueue: Callback[] = [];
   const pushQueue: any[] = [];
 


### PR DESCRIPTION
Some minimal compatibility changes (see commits for additional clarity) to
prepare for `graphql@15`, which is currently in release candidate stages.

I should note that this PR doesn't attempt to get close to the more
comprehensive set of changes which @yaacovCR's
https://github.com/apollographql/graphql-tools/pull/1206 brings.

Instead, I'm aiming to provide the minimum compatibility with the least number of breaking changes
in order to continue to support Apollo Server v2, which completely re-exports
the current `graphql-tools@4` version.

Future versions of Apollo Server will lessen their reliance on this
`graphql-tools` package and will also deprecate older versions of `graphql`
which are still supported by it today (including 0.13.x versions).  In the
meantime, I hope this will allow the v2 series of Apollo Server to make it
through `graphql@15`.  (I do not have this same expecation for `graphql@16`,
and we expect to make changes in Apollo Server 3.x which speak to that.)

I've copied and pasted some of my commit log messages here which are included
in this PR:

```
66d73a8 (Jesse Rosenberger, 5 hours ago)
   compat: filter extensions prior to passing to `buildASTSchema`.

   .@IvanGoncharov originally brought this to my attention when he pointed me
   to 
   https://github.com/yaacovCR/graphql-tools-fork/issues/32#issuecomment-571252686 
   and suggested stripping extension nodes prior to invoking `buildASTSchema` 
   as a cross-version (v14 <=> v15) approach for interim compatibility on the 
   v4 series of `graphql-tools`.

   The most urgent and pertinent need here from my perspective is to allow 
   user-exploration of the new `graphql@15` release candidate within Apollo 
   Server which currently re-exports the entirety of `graphql-tools` (even 
   though it only relies on small portions of it).

   Upon further investigation of the above-referenced issue, it appears that
   @yaacovCR had already crafted the solution that @IvanGoncharov had
   suggested to me, which I found in 2280eef8ad6c1cbc90c640228eb68094546f60f9
   within the well-organized
   https://github.com/apollographql/graphql-tools/pull/1206
   (which I am thankful for the continued updates on!).

   My commit here merely grabs a sub-set of that commit that seemed most 
   pertinent; I certainly don't claim that this solution is nearly as 
   comprehensive as the original 2280eef8ad6c1cbc90c640228eb68094546f60f9.  My 
   hope is that by using the same code/implementation here, it will marginally 
   lessen future merge conflicts.

   Since this is basically a re-working of @yaacovCR's commit, I've attributed 
   co-authorship of this commit accordingly.  (Thank you, again!)

   Ref: https://github.com/apollographql/graphql-tools/issues/1272 
   Co-authored-by: yaacovCR <yaacovCR@gmail.com>

c7f5088 (Jesse Rosenberger, 5 hours ago)
   Fix incompatibility between `iterall` and newer TypeScript types.

   This wouldn't be necessary if this project had a `package-lock.json`,
   but...

713ffe2 (Jesse Rosenberger, 6 hours ago)
   Inline `PrintSchemaOptions` type, whose parent module has been moved.

   This option will likely be deprecated in `graphql@16`.  For now, we'll 
   inline this type into this module to continue emitting it into the 
   declaration file for `makeRemoteExecutableSchema`.

   This is necessary since the TypeScript compiler can no longer resolve its 
   previous location as `graphql` has moved the location of the
   `schemaPrinter` module to `printSchema` in
   https://github.com/graphql/graphql-js/pull/2426.

```