### PR TITLE
refactor(types): use graphql v15 types

### DIFF
--- a/src/generate/extendResolversFromInterfaces.ts
+++ b/src/generate/extendResolversFromInterfaces.ts
@@ -1,9 +1,4 @@
-import {
-  GraphQLObjectType,
-  GraphQLSchema,
-  isObjectType,
-  isInterfaceType,
-} from 'graphql';
+import { GraphQLSchema, isObjectType, isInterfaceType } from 'graphql';
 
 import { IResolvers } from '../Interfaces';
 import { graphqlVersion } from '../utils/index';
@@ -25,7 +20,7 @@ function extendResolversFromInterfaces(
       isObjectType(type) ||
       (graphqlVersion() >= 15 && isInterfaceType(type))
     ) {
-      const interfaceResolvers = (type as GraphQLObjectType)
+      const interfaceResolvers = type
         .getInterfaces()
         .map((iFace) => resolvers[iFace.name]);
       extendedResolvers[typeName] = Object.assign(

--- a/src/polyfills/toConfig.ts
+++ b/src/polyfills/toConfig.ts
@@ -90,10 +90,11 @@ export function toConfig(
   },
 ): GraphQLObjectTypeConfig<any, any>;
 export function toConfig(
-  graphqlObject: GraphQLInterfaceType,
-): GraphQLInterfaceTypeConfig<any, any> & {
-  fields: GraphQLFieldConfigMap<any, any>;
-};
+  graphqlObject: GraphQLInterfaceType & {
+    interfaces: Array<GraphQLInterfaceType>;
+    fields: GraphQLFieldConfigMap<any, any>;
+  },
+): GraphQLInterfaceTypeConfig<any, any>;
 export function toConfig(
   graphqlObject: GraphQLUnionType,
 ): GraphQLUnionTypeConfig<any, any> & {
@@ -217,7 +218,7 @@ export function interfaceTypeToConfig(
     return type.toConfig();
   }
 
-  const typeConfig = {
+  const typeConfig: GraphQLInterfaceTypeConfig<any, any> = {
     name: type.name,
     description: type.description,
     fields: fieldMapToConfig(type.getFields()),
@@ -229,10 +230,7 @@ export function interfaceTypeToConfig(
   };
 
   if (graphqlVersion() >= 15) {
-    ((typeConfig as unknown) as GraphQLObjectTypeConfig<
-      any,
-      any
-    >).interfaces = ((type as unknown) as GraphQLObjectType).getInterfaces();
+    typeConfig.interfaces = type.getInterfaces();
   }
 
   return typeConfig;
@@ -380,8 +378,7 @@ export function directiveToConfig(
     description: directive.description,
     locations: directive.locations,
     args: argumentMapToConfig(directive.args),
-    isRepeatable: ((directive as unknown) as { isRepeatable: boolean })
-      .isRepeatable,
+    isRepeatable: directive.isRepeatable,
     extensions: directive.extensions,
     astNode: directive.astNode,
   };

--- a/src/utils/clone.ts
+++ b/src/utils/clone.ts
@@ -4,7 +4,6 @@ import {
   GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLObjectType,
-  GraphQLObjectTypeConfig,
   GraphQLNamedType,
   GraphQLScalarType,
   GraphQLSchema,
@@ -43,13 +42,9 @@ export function cloneType(type: GraphQLNamedType): GraphQLNamedType {
       ...config,
       interfaces:
         graphqlVersion() >= 15
-          ? typeof ((config as unknown) as GraphQLObjectTypeConfig<any, any>)
-              .interfaces === 'function'
-            ? ((config as unknown) as GraphQLObjectTypeConfig<any, any>)
-                .interfaces
-            : ((config as unknown) as {
-                interfaces: Array<GraphQLInterfaceType>;
-              }).interfaces.slice()
+          ? typeof config.interfaces === 'function'
+            ? config.interfaces
+            : config.interfaces.slice()
           : undefined,
     };
     return new GraphQLInterfaceType(newConfig);

--- a/src/utils/heal.ts
+++ b/src/utils/heal.ts
@@ -24,7 +24,7 @@ import {
 import { toConfig } from '../polyfills/index';
 
 import updateEachKey from './updateEachKey';
-import { isStub, getBuiltInForStub } from './stub';
+import { isNamedStub, getBuiltInForStub } from './stub';
 import { graphqlVersion } from './graphqlVersion';
 
 type NamedTypeMap = Record<string, GraphQLNamedType>;
@@ -197,7 +197,7 @@ export function healTypes(
   }
 
   function healInterfaces(type: GraphQLObjectType | GraphQLInterfaceType) {
-    updateEachKey((type as GraphQLObjectType).getInterfaces(), (iface) => {
+    updateEachKey(type.getInterfaces(), (iface) => {
       const healedType = healType(iface) as GraphQLInterfaceType;
       return healedType;
     });
@@ -234,7 +234,7 @@ export function healTypes(
       // the official type will be undefined, not null.
       let officialType = originalTypeMap[type.name];
       if (officialType === undefined) {
-        if (isStub(type)) {
+        if (isNamedStub(type)) {
           officialType = getBuiltInForStub(type);
         } else {
           officialType = type;
@@ -258,7 +258,7 @@ function pruneTypes(
       isObjectType(namedType) ||
       (graphqlVersion() >= 15 && isInterfaceType(namedType))
     ) {
-      (namedType as GraphQLObjectType).getInterfaces().forEach((iface) => {
+      namedType.getInterfaces().forEach((iface) => {
         implementedInterfaces[iface.name] = true;
       });
     }

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -25,7 +25,6 @@ import {
   isObjectType,
   isScalarType,
   isUnionType,
-  GraphQLObjectTypeConfig,
 } from 'graphql';
 
 import { toConfig } from '../polyfills/toConfig';
@@ -264,14 +263,7 @@ export function rewireTypes(
         fields: () => rewireFields(config.fields),
       };
       if (graphqlVersion() >= 15) {
-        ((newConfig as unknown) as GraphQLObjectTypeConfig<
-          any,
-          any
-        >).interfaces = () =>
-          rewireNamedTypes(
-            ((config as unknown) as { interfaces: Array<GraphQLInterfaceType> })
-              .interfaces,
-          );
+        newConfig.interfaces = () => rewireNamedTypes(config.interfaces);
       }
       return new GraphQLInterfaceType(newConfig);
     } else if (isUnionType(type)) {
@@ -333,7 +325,9 @@ export function rewireTypes(
     return rewiredFields;
   }
 
-  function rewireNamedTypes<T extends GraphQLNamedType>(namedTypes: Array<T>) {
+  function rewireNamedTypes<T extends GraphQLNamedType>(
+    namedTypes: Array<T>,
+  ): Array<T> {
     const rewiredTypes: Array<T> = [];
     namedTypes.forEach((namedType) => {
       const rewiredType = rewireType(namedType);
@@ -379,7 +373,7 @@ function pruneTypes(
       isObjectType(namedType) ||
       (graphqlVersion() >= 15 && isInterfaceType(namedType))
     ) {
-      (namedType as GraphQLObjectType).getInterfaces().forEach((iface) => {
+      namedType.getInterfaces().forEach((iface) => {
         implementedInterfaces[iface.name] = true;
       });
     }


### PR DESCRIPTION
- use v15 interface types for interfaces, as v15 types allow interfaces to have interfaces without casting to objects
- this change also streamlines types for stub type creation