### PR TITLE
fix(exports): trim exports

### DIFF
--- a/src/delegate/createRequest.ts
+++ b/src/delegate/createRequest.ts
@@ -17,7 +17,7 @@ import {
 } from 'graphql';
 
 import { ICreateRequestFromInfo, Request, ICreateRequest } from '../Interfaces';
-import { serializeInputValue } from '../utils/index';
+import { serializeInputValue } from '../utils/transformInputValue';
 import { updateArgument } from '../utils/updateArgument';
 import { keyMap } from '../utils/keyMap';
 

--- a/src/generate/addResolversToSchema.ts
+++ b/src/generate/addResolversToSchema.ts
@@ -15,13 +15,11 @@ import {
   IResolverValidationOptions,
   IAddResolversToSchemaOptions,
 } from '../Interfaces';
+import { healSchema, forEachField, forEachDefaultValue } from '../utils/index';
 import {
   parseInputValue,
   serializeInputValue,
-  healSchema,
-  forEachField,
-  forEachDefaultValue,
-} from '../utils/index';
+} from '../utils/transformInputValue';
 import { toConfig } from '../polyfills/index';
 import keyValMap from '../utils/keyValMap';
 

--- a/src/stitch/index.ts
+++ b/src/stitch/index.ts
@@ -1,14 +1,5 @@
 import introspectSchema from './introspectSchema';
 import mergeSchemas from './mergeSchemas';
 import defaultMergedResolver from './defaultMergedResolver';
-import { createMergedResolver } from './createMergedResolver';
-import { dehoistResult, unwrapResult } from './proxiedResult';
 
-export {
-  introspectSchema,
-  mergeSchemas,
-  defaultMergedResolver,
-  createMergedResolver,
-  dehoistResult,
-  unwrapResult,
-};
+export { introspectSchema, mergeSchemas, defaultMergedResolver };

--- a/src/stitch/mergeInfo.ts
+++ b/src/stitch/mergeInfo.ts
@@ -25,9 +25,11 @@ import AddReplacementFragments from '../wrap/transforms/AddReplacementFragments'
 import {
   parseFragmentToInlineFragment,
   concatInlineFragments,
+} from '../utils/fragments';
+import {
   typeContainsSelectionSet,
   parseSelectionSet,
-} from '../utils/index';
+} from '../utils/selectionSets';
 
 import delegateToSchema from '../delegate/delegateToSchema';
 import { hasOwnProperty } from '../utils/hasOwnProperty';

--- a/src/test/alternateMergeSchemas.test.ts
+++ b/src/test/alternateMergeSchemas.test.ts
@@ -32,15 +32,15 @@ import { isSpecifiedScalarType, toConfig } from '../polyfills/index';
 
 import { delegateToSchema } from '../delegate/index';
 import { makeExecutableSchema } from '../generate/index';
-import { mergeSchemas, createMergedResolver } from '../stitch/index';
+import { mergeSchemas } from '../stitch/index';
+import { createMergedResolver } from '../stitch/createMergedResolver';
 import { SubschemaConfig } from '../Interfaces';
+import { filterSchema, graphqlVersion } from '../utils/index';
 import {
-  filterSchema,
   wrapFieldNode,
   renameFieldNode,
   hoistFieldNodes,
-  graphqlVersion,
-} from '../utils/index';
+} from '../utils/fieldNodes';
 
 import {
   propertySchema,

--- a/src/test/transforms.test.ts
+++ b/src/test/transforms.test.ts
@@ -27,7 +27,7 @@ import {
 import {
   concatInlineFragments,
   parseFragmentToInlineFragment,
-} from '../utils/index';
+} from '../utils/fragments';
 import { addMocksToSchema } from '../mock/index';
 
 import { propertySchema, bookingSchema } from './fixtures/schemas';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,25 +7,6 @@ export { visitSchema } from './visitSchema';
 export { getResolversFromSchema } from './getResolversFromSchema';
 export { forEachField } from './forEachField';
 export { forEachDefaultValue } from './forEachDefaultValue';
-export {
-  transformInputValue,
-  parseInputValue,
-  parseInputValueLiteral,
-  serializeInputValue,
-} from './transformInputValue';
-export {
-  concatInlineFragments,
-  parseFragmentToInlineFragment,
-} from './fragments';
-export { parseSelectionSet, typeContainsSelectionSet } from './selectionSets';
 export { mergeDeep } from './mergeDeep';
-export {
-  collectFields,
-  wrapFieldNode,
-  renameFieldNode,
-  hoistFieldNodes,
-} from './fieldNodes';
-export { appendFields, removeFields } from './fields';
-export { createNamedStub } from './stub';
 export { graphqlVersion } from './graphqlVersion';
 export { mapSchema } from './map';

--- a/src/wrap/transforms/AddArgumentsAsVariables.ts
+++ b/src/wrap/transforms/AddArgumentsAsVariables.ts
@@ -13,7 +13,7 @@ import {
 } from 'graphql';
 
 import { Transform, Request } from '../../Interfaces';
-import { serializeInputValue } from '../../utils/index';
+import { serializeInputValue } from '../../utils/transformInputValue';
 import { updateArgument } from '../../utils/updateArgument';
 import toObjMap from '../../utils/toObjMap';
 import keyValMap from '../../utils/keyValMap';

--- a/src/wrap/transforms/HoistField.ts
+++ b/src/wrap/transforms/HoistField.ts
@@ -1,7 +1,8 @@
 import { GraphQLSchema, GraphQLObjectType, getNullableType } from 'graphql';
 
-import { healSchema, wrapFieldNode, renameFieldNode } from '../../utils/index';
-import { createMergedResolver } from '../../stitch/index';
+import { healSchema } from '../../utils/index';
+import { wrapFieldNode, renameFieldNode } from '../../utils/fieldNodes';
+import { createMergedResolver } from '../../stitch/createMergedResolver';
 import { appendFields, removeFields } from '../../utils/fields';
 import { Transform, Request } from '../../Interfaces';
 

--- a/src/wrap/transforms/ReplaceFieldWithFragment.ts
+++ b/src/wrap/transforms/ReplaceFieldWithFragment.ts
@@ -12,7 +12,7 @@ import {
   visitWithTypeInfo,
 } from 'graphql';
 
-import { concatInlineFragments } from '../../utils/index';
+import { concatInlineFragments } from '../../utils/fragments';
 import { Transform, Request } from '../../Interfaces';
 
 export default class ReplaceFieldWithFragment implements Transform {

--- a/src/wrap/transforms/WrapFields.ts
+++ b/src/wrap/transforms/WrapFields.ts
@@ -1,16 +1,11 @@
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
 import { Transform, Request } from '../../Interfaces';
-import {
-  hoistFieldNodes,
-  healSchema,
-  appendFields,
-  removeFields,
-} from '../../utils/index';
-import {
-  defaultMergedResolver,
-  createMergedResolver,
-} from '../../stitch/index';
+import { healSchema } from '../../utils/index';
+import { hoistFieldNodes } from '../../utils/fieldNodes';
+import { appendFields, removeFields } from '../../utils/fields';
+import { defaultMergedResolver } from '../../stitch/index';
+import { createMergedResolver } from '../../stitch/createMergedResolver';
 
 import MapFields from './MapFields';
 


### PR DESCRIPTION
graphql-tools-fork exported almost all utilities. graphql-tools should have a smaller (and more stable) api surface.