### PR TITLE
feat(proxying): support custom resolver generation

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -133,6 +133,7 @@ export interface SubschemaConfig {
   dispatcher?: Dispatcher;
   transforms?: Array<Transform>;
   merge?: Record<string, MergedTypeConfig>;
+  createProxyingResolver?: CreateProxyingResolverFn;
 }
 
 export interface MergedTypeConfig {
@@ -594,3 +595,13 @@ export type DirectiveMapper = (
   directive: GraphQLDirective,
   schema: GraphQLSchema,
 ) => GraphQLDirective | null | undefined;
+
+export interface ICreateProxyingResolverOptions {
+  schema?: GraphQLSchema | SubschemaConfig;
+  transforms?: Array<Transform>;
+  operation?: Operation;
+}
+
+export type CreateProxyingResolverFn = (
+  options: ICreateProxyingResolverOptions,
+) => GraphQLFieldResolver<any, any>;

--- a/src/wrap/index.ts
+++ b/src/wrap/index.ts
@@ -6,4 +6,5 @@ export * from './transforms/index';
 export {
   default as makeRemoteExecutableSchema,
   defaultCreateRemoteResolver,
+  defaultCreateRemoteSubscriptionResolver,
 } from './makeRemoteExecutableSchema';

--- a/src/wrap/resolvers.ts
+++ b/src/wrap/resolvers.ts
@@ -21,21 +21,9 @@ import { getErrors } from '../stitch/errors';
 export function generateProxyingResolvers({
   subschemaConfig,
   transforms,
-  createProxyingResolver = defaultCreateProxyingResolver,
 }: {
   subschemaConfig: SubschemaConfig;
   transforms?: Array<Transform>;
-  createProxyingResolver?: ({
-    schema,
-    transforms,
-    operation,
-    fieldName,
-  }: {
-    schema?: GraphQLSchema | SubschemaConfig;
-    transforms?: Array<Transform>;
-    operation?: Operation;
-    fieldName?: string;
-  }) => GraphQLFieldResolver<any, any>;
 }): IResolvers {
   const targetSchema = subschemaConfig.schema;
 
@@ -44,6 +32,11 @@ export function generateProxyingResolvers({
     mutation: targetSchema.getMutationType(),
     subscription: targetSchema.getSubscriptionType(),
   };
+
+  const createProxyingResolver =
+    subschemaConfig.createProxyingResolver != null
+      ? subschemaConfig.createProxyingResolver
+      : defaultCreateProxyingResolver;
 
   const resolvers = {};
   Object.keys(operationTypes).forEach((operation: Operation) => {
@@ -58,9 +51,8 @@ export function generateProxyingResolvers({
         resolvers[typeName][fieldName] = {
           [resolveField]: createProxyingResolver({
             schema: subschemaConfig,
-            operation,
-            fieldName,
             transforms,
+            operation,
           }),
         };
       });

--- a/src/wrap/wrapSchema.ts
+++ b/src/wrap/wrapSchema.ts
@@ -18,12 +18,15 @@ export function wrapSchema(
     : { schema: subschemaOrSubschemaConfig };
 
   const schema = cloneSchema(subschemaConfig.schema);
+
   stripResolvers(schema);
 
-  addResolversToSchema({
-    schema,
-    resolvers: generateProxyingResolvers({ subschemaConfig, transforms }),
+  const resolvers = generateProxyingResolvers({
+    subschemaConfig,
+    transforms,
   });
+
+  addResolversToSchema({ schema, resolvers });
 
   let schemaTransforms: Array<Transform> = [];
   if (subschemaConfig.transforms != null) {


### PR DESCRIPTION
 = add support for custom subscription resolver generation to makeRemoteExecutableSchema
 = adds support for customizing resolver generation to schema config objects and thereby to wrapSchema/transformSchema, mergeSchemas
 = closes #1302 

