### PR TITLE
refactor(createProxyingResolver): finish new functionality

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -126,14 +126,12 @@ export type Dispatcher = (context: any) => ApolloLink | Fetcher;
 export interface SubschemaConfig {
   schema: GraphQLSchema;
   rootValue?: Record<string, any>;
-  executor?: Delegator;
-  subscriber?: Delegator;
   link?: ApolloLink;
   fetcher?: Fetcher;
   dispatcher?: Dispatcher;
+  createProxyingResolver?: CreateProxyingResolverFn;
   transforms?: Array<Transform>;
   merge?: Record<string, MergedTypeConfig>;
-  createProxyingResolver?: CreateProxyingResolverFn;
 }
 
 export interface MergedTypeConfig {
@@ -596,12 +594,9 @@ export type DirectiveMapper = (
   schema: GraphQLSchema,
 ) => GraphQLDirective | null | undefined;
 
-export interface ICreateProxyingResolverOptions {
-  schema?: GraphQLSchema | SubschemaConfig;
-  transforms?: Array<Transform>;
-  operation?: Operation;
-}
-
 export type CreateProxyingResolverFn = (
-  options: ICreateProxyingResolverOptions,
+  schema: GraphQLSchema | SubschemaConfig,
+  transforms: Array<Transform>,
+  operation: Operation,
+  fieldName: string,
 ) => GraphQLFieldResolver<any, any>;

--- a/src/wrap/index.ts
+++ b/src/wrap/index.ts
@@ -1,6 +1,8 @@
 export { wrapSchema } from './wrapSchema';
 export { transformSchema } from './transformSchema';
 
+export { defaultCreateProxyingResolver } from './resolvers';
+
 export * from './transforms/index';
 
 export {


### PR DESCRIPTION
finishes work in #1349 for #1302

= streamlines the CreateProxyingResolverFn signature as no further arguments expected, pass along all info to users for possible customization
= adds fix for nested root query object to makeRemoteExecutableSchema
= actually export defaultCreateProxyingResolver
= reorders properties of SubschemaConfig, removes some unused properties