### PR TITLE
fix(introspectSchema): avoid instanceOf check

### DIFF
--- a/src/stitch/introspectSchema.ts
+++ b/src/stitch/introspectSchema.ts
@@ -19,9 +19,9 @@ export default function introspectSchema(
   linkContext?: { [key: string]: any },
 ): Promise<GraphQLSchema> {
   const fetcher =
-    linkOrFetcher instanceof ApolloLink
-      ? linkToFetcher(linkOrFetcher)
-      : linkOrFetcher;
+    typeof linkOrFetcher === 'function'
+      ? linkOrFetcher
+      : linkToFetcher(linkOrFetcher);
 
   return fetcher({
     query: parsedIntrospectionQuery,


### PR DESCRIPTION
Using instanceOf causes problems is a project includes multiple versions of ApolloLink.