### PR TITLE
fix(types): standardize types

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -1,7 +1,6 @@
 import {
   GraphQLSchema,
   GraphQLField,
-  ExecutionResult,
   GraphQLInputType,
   GraphQLType,
   GraphQLNamedType,
@@ -28,13 +27,54 @@ import {
   FragmentDefinitionNode,
   SelectionNode,
   VariableDefinitionNode,
+  OperationDefinitionNode,
+  GraphQLError,
+  ExecutionResult as GraphQLExecutionResult,
 } from 'graphql';
 
-import { TypeMap } from 'graphql/type/schema';
 import { ApolloLink } from 'apollo-link';
 
 import { SchemaVisitor } from './utils/SchemaVisitor';
 import { SchemaDirectiveVisitor } from './utils/SchemaDirectiveVisitor';
+
+// graphql-js < v15 backwards compatible ExecutionResult
+// See: https://github.com/graphql/graphql-js/pull/2490
+
+export interface ExecutionResult<
+  TData = {
+    [key: string]: any;
+  }
+> extends GraphQLExecutionResult {
+  data?: TData | null;
+  extensions?: Record<string, any>;
+}
+
+// for backwards compatibility
+export type Result = ExecutionResult;
+
+// graphql-js non-exported typings
+
+export type TypeMap = Record<string, GraphQLNamedType>;
+
+export interface GraphQLExecutionContext {
+  schema: GraphQLSchema;
+  fragments: { [key: string]: FragmentDefinitionNode };
+  rootValue: any;
+  contextValue: any;
+  operation: OperationDefinitionNode;
+  variableValues: { [key: string]: any };
+  fieldResolver: GraphQLFieldResolver<any, any>;
+  errors: Array<GraphQLError>;
+}
+
+export interface GraphQLParseOptions {
+  noLocation?: boolean;
+  allowLegacySDLEmptyFields?: boolean;
+  allowLegacySDLImplementsInterfaces?: boolean;
+  experimentalFragmentVariables?: boolean;
+}
+
+// graphql-tools typings
 
 export interface IResolverValidationOptions {
   requireResolversForArgs?: boolean;
@@ -71,9 +111,9 @@ export interface IResolverOptions<TSource = any, TContext = any, TArgs = any> {
 }
 
 export interface Transform {
-  transformSchema?: (schema: GraphQLSchema) => GraphQLSchema;
+  transformSchema?: (originalSchema: GraphQLSchema) => GraphQLSchema;
   transformRequest?: (originalRequest: Request) => Request;
-  transformResult?: (result: Result) => Result;
+  transformResult?: (originalResult: ExecutionResult) => ExecutionResult;
 }
 
 export type FieldTransformer = (
@@ -379,17 +419,6 @@ export interface Request {
   document: DocumentNode;
   variables: Record<string, any>;
   extensions?: Record<string, any>;
-}
-
-export interface Result extends ExecutionResult {
-  extensions?: Record<string, any>;
-}
-
-export interface GraphQLParseOptions {
-  noLocation?: boolean;
-  allowLegacySDLEmptyFields?: boolean;
-  allowLegacySDLImplementsInterfaces?: boolean;
-  experimentalFragmentVariables?: boolean;
 }
 
 export type IndexedObject<V> = { [key: string]: V } | ReadonlyArray<V>;

--- a/src/delegate/results/handleObject.ts
+++ b/src/delegate/results/handleObject.ts
@@ -6,7 +6,6 @@ import {
   FieldNode,
   GraphQLObjectType,
 } from 'graphql';
-import { ExecutionContext } from 'graphql/execution/execute';
 
 import { collectFields } from '../../utils/collectFields';
 
@@ -15,6 +14,7 @@ import {
   IGraphQLToolsResolveInfo,
   MergedTypeInfo,
   isSubschemaConfig,
+  GraphQLExecutionContext,
 } from '../../Interfaces';
 import { setErrors, relocatedError } from '../../stitch/errors';
 import { setObjectSubschema } from '../../stitch/subSchema';
@@ -96,7 +96,7 @@ function collectSubFields(info: IGraphQLToolsResolveInfo, typeName: string) {
         schema: info.schema,
         variableValues: info.variableValues,
         fragments: info.fragments,
-      } as unknown) as ExecutionContext,
+      } as unknown) as GraphQLExecutionContext,
       info.schema.getType(typeName) as GraphQLObjectType,
       fieldNode.selectionSet,
       subFieldNodes,

--- a/src/stitch/mergeInfo.ts
+++ b/src/stitch/mergeInfo.ts
@@ -8,7 +8,6 @@ import {
   isObjectType,
   isScalarType,
 } from 'graphql';
-import { TypeMap } from 'graphql/type/schema';
 
 import {
   IDelegateToSchemaOptions,
@@ -19,6 +18,7 @@ import {
   IGraphQLToolsResolveInfo,
   MergedTypeInfo,
   Transform,
+  TypeMap,
 } from '../Interfaces';
 import ExpandAbstractTypes from '../wrap/transforms/ExpandAbstractTypes';
 import AddReplacementFragments from '../wrap/transforms/AddReplacementFragments';

--- a/src/test/fixtures/schemas.ts
+++ b/src/test/fixtures/schemas.ts
@@ -1,9 +1,5 @@
 import { PubSub } from 'graphql-subscriptions';
-import {
-  ApolloLink,
-  Observable,
-  ExecutionResult as LinkExecutionResult,
-} from 'apollo-link';
+import { ApolloLink, Observable } from 'apollo-link';
 import {
   GraphQLSchema,
   graphql,
@@ -12,13 +8,17 @@ import {
   Kind,
   GraphQLScalarType,
   ValueNode,
-  ExecutionResult,
   GraphQLResolveInfo,
 } from 'graphql';
 import { forAwaitEach } from 'iterall';
 
 import introspectSchema from '../../stitch/introspectSchema';
-import { IResolvers, Fetcher, SubschemaConfig } from '../../Interfaces';
+import {
+  IResolvers,
+  Fetcher,
+  SubschemaConfig,
+  ExecutionResult,
+} from '../../Interfaces';
 import { makeExecutableSchema } from '../../generate/index';
 import { graphqlVersion } from '../../utils/index';
 
@@ -729,7 +729,7 @@ function makeLinkFromSchema(schema: GraphQLSchema) {
                   .then(() => observer.complete())
                   .catch((err) => observer.error(err));
               } else {
-                observer.next(results as LinkExecutionResult);
+                observer.next(results as ExecutionResult);
                 observer.complete();
               }
             })

--- a/src/utils/collectFields.ts
+++ b/src/utils/collectFields.ts
@@ -1,4 +1,3 @@
-import { ExecutionContext } from 'graphql/execution/execute';
 import {
   GraphQLObjectType,
   SelectionSetNode,
@@ -14,6 +13,8 @@ import {
   isAbstractType,
 } from 'graphql';
 
+import { GraphQLExecutionContext } from '../Interfaces';
+
 /**
  * Given a selectionSet, adds all of the fields in that selection to
  * the passed in map of fields, and returns it at the end.
@@ -25,7 +26,7 @@ import {
  * @internal
  */
 export function collectFields(
-  exeContext: ExecutionContext,
+  exeContext: GraphQLExecutionContext,
   runtimeType: GraphQLObjectType,
   selectionSet: SelectionSetNode,
   fields: Record<string, Array<FieldNode>>,
@@ -95,7 +96,7 @@ export function collectFields(
  * directives, where @skip has higher precedence than @include.
  */
 function shouldIncludeNode(
-  exeContext: ExecutionContext,
+  exeContext: GraphQLExecutionContext,
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode,
 ): boolean {
   const skip = getDirectiveValues(
@@ -125,7 +126,7 @@ function shouldIncludeNode(
  * Determines if a fragment is applicable to the given type.
  */
 function doesFragmentConditionMatch(
-  exeContext: ExecutionContext,
+  exeContext: GraphQLExecutionContext,
   fragment: FragmentDefinitionNode | InlineFragmentNode,
   type: GraphQLObjectType,
 ): boolean {

--- a/src/utils/fields.ts
+++ b/src/utils/fields.ts
@@ -3,10 +3,10 @@ import {
   GraphQLObjectType,
   GraphQLFieldConfig,
 } from 'graphql';
-import { TypeMap } from 'graphql/type/schema';
 
 import { toConfig } from '../polyfills/index';
 import toObjMap from '../esUtils/toObjMap';
+import { TypeMap } from '../Interfaces';
 
 export function appendFields(
   typeMap: TypeMap,

--- a/src/wrap/transforms/RenameRootTypes.ts
+++ b/src/wrap/transforms/RenameRootTypes.ts
@@ -6,7 +6,12 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 
-import { Request, Result, MapperKind, Transform } from '../../Interfaces';
+import {
+  Request,
+  ExecutionResult,
+  MapperKind,
+  Transform,
+} from '../../Interfaces';
 import { mapSchema } from '../../utils/index';
 import { toConfig } from '../../polyfills/index';
 
@@ -59,7 +64,7 @@ export default class RenameRootTypes implements Transform {
     };
   }
 
-  public transformResult(result: Result): Result {
+  public transformResult(result: ExecutionResult): ExecutionResult {
     return {
       ...result,
       data: this.transformData(result.data),

--- a/src/wrap/transforms/RenameTypes.ts
+++ b/src/wrap/transforms/RenameTypes.ts
@@ -19,7 +19,12 @@ import {
 } from 'graphql';
 
 import { isSpecifiedScalarType, toConfig } from '../../polyfills/index';
-import { Transform, Request, Result, MapperKind } from '../../Interfaces';
+import {
+  Transform,
+  Request,
+  ExecutionResult,
+  MapperKind,
+} from '../../Interfaces';
 import { mapSchema } from '../../utils/index';
 
 export type RenameOptions = {
@@ -112,7 +117,7 @@ export default class RenameTypes implements Transform {
     };
   }
 
-  public transformResult(result: Result): Result {
+  public transformResult(result: ExecutionResult): ExecutionResult {
     return {
       ...result,
       data: this.transformData(result.data),

--- a/src/wrap/transforms/TransformQuery.ts
+++ b/src/wrap/transforms/TransformQuery.ts
@@ -6,7 +6,7 @@ import {
   GraphQLError,
 } from 'graphql';
 
-import { Transform, Request, Result } from '../../Interfaces';
+import { Transform, Request, ExecutionResult } from '../../Interfaces';
 
 export type QueryTransformer = (
   selectionSet: SelectionSetNode,
@@ -83,7 +83,7 @@ export default class TransformQuery implements Transform {
     };
   }
 
-  public transformResult(originalResult: Result): Result {
+  public transformResult(originalResult: ExecutionResult): ExecutionResult {
     const data = this.transformData(originalResult.data);
     const errors = originalResult.errors;
     return {

--- a/src/wrap/transforms/WrapQuery.ts
+++ b/src/wrap/transforms/WrapQuery.ts
@@ -6,7 +6,7 @@ import {
   SelectionSetNode,
 } from 'graphql';
 
-import { Transform, Request, Result } from '../../Interfaces';
+import { Transform, Request, ExecutionResult } from '../../Interfaces';
 
 export type QueryWrapper = (
   subtree: SelectionSetNode,
@@ -65,7 +65,7 @@ export default class WrapQuery implements Transform {
     };
   }
 
-  public transformResult(originalResult: Result): Result {
+  public transformResult(originalResult: ExecutionResult): ExecutionResult {
     const rootData = originalResult.data;
     if (rootData != null) {
       let data = rootData;


### PR DESCRIPTION
= do not rely on external, non-exported graphql-js types
= provide backwards compatible ExecutionResult type that retains typecast from graphql-js <v15
= add extensions property from Result type to graphql-tools ExecutionResult type
= use ExecutionResult type instead of Result
= retain Result type for backwards-compatibility