### PR TITLE
refactor(types): export transform argument types

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -120,7 +120,13 @@ export type FieldTransformer = (
   typeName: string,
   fieldName: string,
   field: GraphQLField<any, any>,
-) => GraphQLFieldConfig<any, any> | RenamedField | null | undefined;
+) => GraphQLFieldConfig<any, any> | RenamedFieldConfig | null | undefined;
+
+export type RootFieldTransformer = (
+  operation: 'Query' | 'Mutation' | 'Subscription',
+  fieldName: string,
+  field: GraphQLField<any, any>,
+) => GraphQLFieldConfig<any, any> | RenamedFieldConfig | null | undefined;
 
 export type FieldNodeTransformer = (
   typeName: string,
@@ -129,10 +135,17 @@ export type FieldNodeTransformer = (
   fragments: Record<string, FragmentDefinitionNode>,
 ) => SelectionNode | Array<SelectionNode>;
 
-export type RenamedField = {
+export type FieldNodeMapper = (
+  fieldNode: FieldNode,
+  fragments: Record<string, FragmentDefinitionNode>,
+) => SelectionNode | Array<SelectionNode>;
+
+export type FieldNodeMappers = Record<string, Record<string, FieldNodeMapper>>;
+
+export interface RenamedFieldConfig {
   name: string;
   field?: GraphQLFieldConfig<any, any>;
-};
+}
 
 export type FieldFilter = (
   typeName?: string,
@@ -145,6 +158,11 @@ export type RootFieldFilter = (
   rootFieldName?: string,
   field?: GraphQLField<any, any>,
 ) => boolean;
+
+export type RenameTypesOptions = {
+  renameBuiltins: boolean;
+  renameScalars: boolean;
+};
 
 export interface IGraphQLToolsResolveInfo extends GraphQLResolveInfo {
   mergeInfo?: MergeInfo;

--- a/src/wrap/transforms/ExpandAbstractTypes.ts
+++ b/src/wrap/transforms/ExpandAbstractTypes.ts
@@ -17,12 +17,10 @@ import {
 import implementsAbstractType from '../../utils/implementsAbstractType';
 import { Transform, Request } from '../../Interfaces';
 
-type TypeMapping = { [key: string]: Array<string> };
-
 export default class ExpandAbstractTypes implements Transform {
   private readonly targetSchema: GraphQLSchema;
-  private readonly mapping: TypeMapping;
-  private readonly reverseMapping: TypeMapping;
+  private readonly mapping: Record<string, Array<string>>;
+  private readonly reverseMapping: Record<string, Array<string>>;
 
   constructor(sourceSchema: GraphQLSchema, targetSchema: GraphQLSchema) {
     this.targetSchema = targetSchema;
@@ -49,7 +47,7 @@ function extractPossibleTypes(
   targetSchema: GraphQLSchema,
 ) {
   const typeMap = sourceSchema.getTypeMap();
-  const mapping: TypeMapping = Object.create(null);
+  const mapping: Record<string, Array<string>> = Object.create(null);
   Object.keys(typeMap).forEach((typeName) => {
     const type = typeMap[typeName];
     if (isAbstractType(type)) {
@@ -65,8 +63,10 @@ function extractPossibleTypes(
   return mapping;
 }
 
-function flipMapping(mapping: TypeMapping): TypeMapping {
-  const result: TypeMapping = Object.create(null);
+function flipMapping(
+  mapping: Record<string, Array<string>>,
+): Record<string, Array<string>> {
+  const result: Record<string, Array<string>> = Object.create(null);
   Object.keys(mapping).forEach((typeName) => {
     const toTypeNames = mapping[typeName];
     toTypeNames.forEach((toTypeName) => {
@@ -81,8 +81,8 @@ function flipMapping(mapping: TypeMapping): TypeMapping {
 
 function expandAbstractTypes(
   targetSchema: GraphQLSchema,
-  mapping: TypeMapping,
-  reverseMapping: TypeMapping,
+  mapping: Record<string, Array<string>>,
+  reverseMapping: Record<string, Array<string>>,
   document: DocumentNode,
 ): DocumentNode {
   const operations: Array<OperationDefinitionNode> = document.definitions.filter(

--- a/src/wrap/transforms/ExtendSchema.ts
+++ b/src/wrap/transforms/ExtendSchema.ts
@@ -5,11 +5,12 @@ import {
   IFieldResolver,
   IResolvers,
   Request,
+  FieldNodeMappers,
 } from '../../Interfaces';
 import { addResolversToSchema } from '../../generate/index';
 import { defaultMergedResolver } from '../../stitch/index';
 
-import MapFields, { FieldNodeTransformerMap } from './MapFields';
+import MapFields from './MapFields';
 
 export default class ExtendSchema implements Transform {
   private readonly typeDefs: string | undefined;
@@ -26,7 +27,7 @@ export default class ExtendSchema implements Transform {
     typeDefs?: string;
     resolvers?: IResolvers;
     defaultFieldResolver?: IFieldResolver<any, any>;
-    fieldNodeTransformerMap?: FieldNodeTransformerMap;
+    fieldNodeTransformerMap?: FieldNodeMappers;
   }) {
     this.typeDefs = typeDefs;
     this.resolvers = resolvers;

--- a/src/wrap/transforms/FilterRootFields.ts
+++ b/src/wrap/transforms/FilterRootFields.ts
@@ -1,19 +1,13 @@
 import { GraphQLField, GraphQLSchema } from 'graphql';
 
-import { Transform } from '../../Interfaces';
+import { Transform, RootFieldFilter } from '../../Interfaces';
 
 import TransformRootFields from './TransformRootFields';
-
-export type RootFilter = (
-  operation: 'Query' | 'Mutation' | 'Subscription',
-  fieldName: string,
-  field: GraphQLField<any, any>,
-) => boolean;
 
 export default class FilterRootFields implements Transform {
   private readonly transformer: TransformRootFields;
 
-  constructor(filter: RootFilter) {
+  constructor(filter: RootFieldFilter) {
     this.transformer = new TransformRootFields(
       (
         operation: 'Query' | 'Mutation' | 'Subscription',

--- a/src/wrap/transforms/MapFields.ts
+++ b/src/wrap/transforms/MapFields.ts
@@ -1,30 +1,14 @@
-import {
-  GraphQLSchema,
-  FieldNode,
-  SelectionNode,
-  FragmentDefinitionNode,
-} from 'graphql';
+import { GraphQLSchema } from 'graphql';
 
-import { Transform, Request } from '../../Interfaces';
+import { Transform, Request, FieldNodeMappers } from '../../Interfaces';
 import { toConfig } from '../../polyfills/index';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export type FieldNodeTransformer = (
-  fieldNode: FieldNode,
-  fragments: Record<string, FragmentDefinitionNode>,
-) => SelectionNode | Array<SelectionNode>;
-
-export type FieldNodeTransformerMap = {
-  [typeName: string]: {
-    [fieldName: string]: FieldNodeTransformer;
-  };
-};
-
 export default class MapFields implements Transform {
   private readonly transformer: TransformObjectFields;
 
-  constructor(fieldNodeTransformerMap: FieldNodeTransformerMap) {
+  constructor(fieldNodeTransformerMap: FieldNodeMappers) {
     this.transformer = new TransformObjectFields(
       (_typeName, _fieldName, field) => toConfig(field),
       (typeName, fieldName, fieldNode, fragments) => {

--- a/src/wrap/transforms/RenameTypes.ts
+++ b/src/wrap/transforms/RenameTypes.ts
@@ -24,13 +24,9 @@ import {
   Request,
   ExecutionResult,
   MapperKind,
+  RenameTypesOptions,
 } from '../../Interfaces';
 import { mapSchema } from '../../utils/index';
-
-export type RenameOptions = {
-  renameBuiltins: boolean;
-  renameScalars: boolean;
-};
 
 export default class RenameTypes implements Transform {
   private readonly renamer: (name: string) => string | undefined;
@@ -41,7 +37,7 @@ export default class RenameTypes implements Transform {
 
   constructor(
     renamer: (name: string) => string | undefined,
-    options?: RenameOptions,
+    options?: RenameTypesOptions,
   ) {
     this.renamer = renamer;
     this.map = Object.create(null);

--- a/src/wrap/transforms/TransformCompositeFields.ts
+++ b/src/wrap/transforms/TransformCompositeFields.ts
@@ -22,22 +22,16 @@ import {
   MapperKind,
   FieldTransformer,
   FieldNodeTransformer,
-  RenamedField,
+  RenamedFieldConfig,
 } from '../../Interfaces';
 import { mapSchema } from '../../utils/index';
 import { toConfig } from '../../polyfills/index';
-
-type FieldMapping = {
-  [typeName: string]: {
-    [newFieldName: string]: string;
-  };
-};
 
 export default class TransformCompositeFields implements Transform {
   private readonly fieldTransformer: FieldTransformer;
   private readonly fieldNodeTransformer: FieldNodeTransformer;
   private transformedSchema: GraphQLSchema;
-  private mapping: FieldMapping;
+  private mapping: Record<string, Record<string, string>>;
 
   constructor(
     fieldTransformer: FieldTransformer,
@@ -100,12 +94,12 @@ export default class TransformCompositeFields implements Transform {
       if (typeof transformedField === 'undefined') {
         newFields[fieldName] = typeConfig.fields[fieldName];
       } else if (transformedField !== null) {
-        const newName = (transformedField as RenamedField).name;
+        const newName = (transformedField as RenamedFieldConfig).name;
 
         if (newName) {
           newFields[newName] =
-            (transformedField as RenamedField).field != null
-              ? (transformedField as RenamedField).field
+            (transformedField as RenamedFieldConfig).field != null
+              ? (transformedField as RenamedFieldConfig).field
               : typeConfig.fields[fieldName];
 
           if (newName !== fieldName) {
@@ -140,7 +134,7 @@ export default class TransformCompositeFields implements Transform {
 
   private transformDocument(
     document: DocumentNode,
-    mapping: FieldMapping,
+    mapping: Record<string, Record<string, string>>,
     fieldNodeTransformer?: FieldNodeTransformer,
     fragments: Record<string, FragmentDefinitionNode> = {},
   ): DocumentNode {

--- a/src/wrap/transforms/TransformRootFields.ts
+++ b/src/wrap/transforms/TransformRootFields.ts
@@ -1,22 +1,19 @@
-import { GraphQLSchema, GraphQLField, GraphQLFieldConfig } from 'graphql';
+import { GraphQLSchema, GraphQLField } from 'graphql';
 
-import { Transform, Request, FieldNodeTransformer } from '../../Interfaces';
+import {
+  Transform,
+  Request,
+  FieldNodeTransformer,
+  RootFieldTransformer,
+} from '../../Interfaces';
 
 import TransformObjectFields from './TransformObjectFields';
-
-export type RootTransformer = (
-  operation: 'Query' | 'Mutation' | 'Subscription',
-  fieldName: string,
-  field: GraphQLField<any, any>,
-) => GraphQLFieldConfig<any, any> | RenamedField | null | undefined;
-
-type RenamedField = { name: string; field?: GraphQLFieldConfig<any, any> };
 
 export default class TransformRootFields implements Transform {
   private readonly transformer: TransformObjectFields;
 
   constructor(
-    rootFieldTransformer: RootTransformer,
+    rootFieldTransformer: RootFieldTransformer,
     fieldNodeTransformer?: FieldNodeTransformer,
   ) {
     const rootToObjectFieldTransformer = (


### PR DESCRIPTION
= public types should be exported for ease of use
= private types do not require aliases